### PR TITLE
Fix: Bank field showing '[object Object]' during statement upload

### DIFF
--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/bank_statement_importer/bank_statement_importer.js
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/bank_statement_importer/bank_statement_importer.js
@@ -72,7 +72,7 @@ frappe.ui.form.on('Bank Statement Importer', {
 				data_body = data?.message?.body;
 				
 				// Apply bank mapping if available
-				const bank_mapping = data?.message?.bank || {};
+				const bank_mapping = data?.message?.bank_mapping || {};
 				console.log("BANK MAPPING", bank_mapping);
 				
 				// Extract file field names directly from bank mapping (now bank fields are keys)

--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/bank_statement_importer/bank_statement_importer.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/bank_statement_importer/bank_statement_importer.py
@@ -110,7 +110,7 @@ def start_import(file_path, bank_account):
             title="Warning",
         )
 
-    return {"header": data_headers, "body": data_body, "bank": bank_mapping}
+    return {"header": data_headers, "body": data_body, "bank_mapping": bank_mapping}
 
 
 def parse_amount(amount_str):


### PR DESCRIPTION
## Summary
- Fixed naming collision between form field "bank" and response data key "bank"
- Renamed response key to "bank_mapping" to prevent Frappe's automatic field binding from setting the Link field to a dictionary object
- Resolves issue where Bank field displays "[object Object]" after clicking "Upload Statement" or "Import" buttons

## Changes
- **Python Backend** ([bank_statement_importer.py](advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/bank_statement_importer/bank_statement_importer.py#L113)): Changed return key from `"bank"` to `"bank_mapping"`
- **JavaScript Frontend** ([bank_statement_importer.js](advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/bank_statement_importer/bank_statement_importer.js#L75)): Updated to reference `bank_mapping` instead of `bank`

## Root Cause
Frappe's `frm.call()` automatically attempts to set form fields based on returned data keys. When the response contained a key named "bank" with a dictionary value, it automatically executed `frm.set_value("bank", {dict})`, causing the Link field to receive an object instead of a string.

## Test Plan
- [ ] Select a bank account in Bank Statement Importer
- [ ] Attach a bank statement file
- [ ] Click "Upload Statement" button
- [ ] Verify the "Bank" field remains properly populated (not showing "[object Object]")
- [ ] Complete the mapping and click "Import"
- [ ] Verify the "Bank" field still displays correctly after import

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal data handling for bank mappings in the bank statement import process to improve system consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->