### PR TITLE
fix(bank-rules): fall back to transaction name when reference number is empty

### DIFF
--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/abr_bank_rule/abr_bank_rule.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/abr_bank_rule/abr_bank_rule.py
@@ -229,7 +229,7 @@ def _execute_rule_action(transaction, rule, logger):
 	if rule.entry_type == "Journal Entry":
 		create_journal_entry_bts(
 			transaction.name,
-			transaction.reference_number,
+			transaction.reference_number or transaction.name,
 			transaction.date,
 			transaction.date,
 			entry_type="Journal Entry",


### PR DESCRIPTION
## Summary
- When a bank transaction has no `reference_number`, Journal Entries created by bank rules failed with "Reference No is mandatory if you entered Reference Date"
- Fall back to the bank transaction name (e.g., `ACC-BTN-2026-00004`) as `cheque_no` when `reference_number` is empty

## Test plan
- [x] All 67 ABR Bank Rule tests pass
- [ ] Run bank rules on transactions with and without reference numbers — verify JEs are created successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved journal entry creation in Advanced Bank Reconciliation rules to properly utilize transaction reference numbers when available, ensuring more accurate reference tracking in generated journal entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->