### PR TITLE
feat(bank-rules): store party as reference on non-receivable/payable JE accounts

### DIFF
--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/abr_bank_rule/test_abr_bank_rule.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/abr_bank_rule/test_abr_bank_rule.py
@@ -1031,3 +1031,81 @@ class TestRunBankRulesEndToEnd(FrappeTestCase):
 			self.assertEqual(result2["unmatched"], 0)
 		finally:
 			cleanup_bank_rule_test(bt.name, rule.name)
+
+	def test_je_rule_with_party_on_receivable_account_uses_party_fields(self):
+		"""Party on Receivable account should use standard party_type/party, not reference fields."""
+		cost_center = frappe.db.get_value("Company", TEST_COMPANY, "cost_center")
+		debtors_account = f"Debtors - {TEST_COMPANY_ABBR}"
+		bt = self._create_bt(deposit=400, description="Customer invoice payment", reference_number="RCV-001")
+		rule = self._create_rule(
+			entry_type="Journal Entry",
+			account=debtors_account,
+			party_type="Customer",
+			party="_Test Customer",
+			cost_center=cost_center,
+			conditions=[{"field_name": "Description", "condition": "Contains", "value": "invoice payment"}],
+		)
+		frappe.db.commit()
+
+		try:
+			result = run_bank_rules(self.bank_account, add_days(today(), -1), today())
+			self.assertEqual(result["matched"], 1)
+			self.assertEqual(result["errors"], 0)
+
+			bt.reload()
+			self.assertEqual(bt.unallocated_amount, 0)
+
+			je = frappe.get_doc("Journal Entry", bt.payment_entries[0].payment_entry)
+			self.assertEqual(je.docstatus, 1)
+
+			second_row = next(
+				(row for row in je.accounts if row.account == debtors_account), None
+			)
+			self.assertIsNotNone(second_row)
+			self.assertEqual(second_row.party_type, "Customer")
+			self.assertEqual(second_row.party, "_Test Customer")
+			self.assertFalse(second_row.reference_type)
+			self.assertFalse(second_row.reference_name)
+			self.assertEqual(second_row.credit_in_account_currency, 400)
+		finally:
+			cleanup_bank_rule_test(bt.name, rule.name)
+
+	def test_je_rule_with_party_on_income_account_stores_as_reference(self):
+		"""Party on non-Receivable/Payable account should be stored as reference_type/reference_name."""
+		cost_center = frappe.db.get_value("Company", TEST_COMPANY, "cost_center")
+		bt = self._create_bt(deposit=250, description="Donation from member", reference_number="DON-001")
+		rule = self._create_rule(
+			entry_type="Journal Entry",
+			account=f"Sales - {TEST_COMPANY_ABBR}",
+			party_type="Customer",
+			party="_Test Customer",
+			cost_center=cost_center,
+			conditions=[{"field_name": "Description", "condition": "Contains", "value": "Donation"}],
+		)
+		frappe.db.commit()
+
+		try:
+			result = run_bank_rules(self.bank_account, add_days(today(), -1), today())
+			self.assertEqual(result["matched"], 1)
+			self.assertEqual(result["errors"], 0)
+
+			bt.reload()
+			self.assertEqual(bt.unallocated_amount, 0)
+			self.assertTrue(len(bt.payment_entries) > 0)
+
+			je = frappe.get_doc("Journal Entry", bt.payment_entries[0].payment_entry)
+			self.assertEqual(je.docstatus, 1)
+
+			# Verify the second account row does NOT have party set (Income account)
+			second_row = next(
+				(row for row in je.accounts if row.account == f"Sales - {TEST_COMPANY_ABBR}"), None
+			)
+			self.assertIsNotNone(second_row)
+			self.assertFalse(second_row.party_type)
+			self.assertFalse(second_row.party)
+			# Party should be stored as reference instead
+			self.assertEqual(second_row.reference_type, "Customer")
+			self.assertEqual(second_row.reference_name, "_Test Customer")
+			self.assertEqual(second_row.credit_in_account_currency, 250)
+		finally:
+			cleanup_bank_rule_test(bt.name, rule.name)

--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/advance_bank_reconciliation_tool.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/advance_bank_reconciliation_tool.py
@@ -215,10 +215,19 @@ def create_journal_entry_bts(
 		"account_currency": second_account_currency,
 		"credit_in_account_currency": deposit,
 		"debit_in_account_currency": withdrawal,
-		"party_type": party_type,
-		"party": party,
 		"cost_center": resolved_cost_center,
 	}
+
+	if party_type and party:
+		if account_type in ["Receivable", "Payable"]:
+			second_account_dict["party_type"] = party_type
+			second_account_dict["party"] = party
+		else:
+			# Cannot use party_type/party on non-Receivable/Payable accounts because
+			# GL Entry validation (validate_account_party_type) rejects it. Store as
+			# reference instead (e.g., donation from a customer on an income account).
+			second_account_dict["reference_type"] = party_type
+			second_account_dict["reference_name"] = party
 
 	company_account_dict = {
 		"account": company_account,

--- a/advanced_bank_reconciliation/hooks.py
+++ b/advanced_bank_reconciliation/hooks.py
@@ -68,7 +68,8 @@ app_license = "gpl-3.0"
 # ------------
 
 # before_install = "advanced_bank_reconciliation.install.before_install"
-# after_install = "advanced_bank_reconciliation.install.after_install"
+after_install = "advanced_bank_reconciliation.setup.after_install"
+after_migrate = "advanced_bank_reconciliation.setup.after_migrate"
 
 # Uninstallation
 # ------------

--- a/advanced_bank_reconciliation/setup.py
+++ b/advanced_bank_reconciliation/setup.py
@@ -1,0 +1,93 @@
+import frappe
+from frappe.custom.doctype.property_setter.property_setter import make_property_setter
+
+from advanced_bank_reconciliation.utils.logger import get_logger
+
+logger = get_logger()
+
+
+def after_install():
+    create_property_setters()
+
+
+def after_migrate():
+    create_property_setters()
+
+
+def create_property_setters():
+    try:
+        for ps in get_property_setters():
+            make_property_setter(
+                doctype=ps["doctype"],
+                fieldname=ps["fieldname"],
+                property=ps["property"],
+                value=ps["value"],
+                property_type=ps.get("property_type", "Text"),
+                for_doctype=ps.get("for_doctype", False),
+                validate_fields_for_doctype=False,
+            )
+    except Exception as e:
+        logger.error("ABR setup: Failed to create property setters", exc_info=True)
+        frappe.db.rollback()
+        frappe.log_error(
+            message="Failed to create property setters during ABR setup.\n\n%s" % e,
+            title="ABR Setup: Property Setter Creation Failed",
+        )
+        frappe.db.commit()
+
+
+def get_property_setters():
+    property_setters = []
+
+    extended_options = get_extended_reference_type_options()
+    if extended_options:
+        property_setters.append(
+            {
+                "doctype": "Journal Entry Account",
+                "fieldname": "reference_type",
+                "property": "options",
+                "value": extended_options,
+                "property_type": "Text",
+            }
+        )
+
+    return property_setters
+
+
+def get_extended_reference_type_options():
+    """Extend JE Account reference_type options with Customer/Supplier.
+
+    This allows bank rules to store a party reference on non-Receivable/Payable
+    accounts (e.g., tracking a customer donation on an income account) without
+    triggering ERPNext's party-account-type validation.
+    """
+    new_types = ["Customer", "Supplier"]
+
+    try:
+        meta = frappe.get_meta("Journal Entry Account")
+    except Exception:
+        logger.error(
+            "ABR setup: Could not load meta for 'Journal Entry Account'", exc_info=True
+        )
+        raise
+
+    ref_type_field = meta.get_field("reference_type")
+
+    if not ref_type_field or not ref_type_field.options:
+        logger.warning(
+            "ABR setup: 'reference_type' field not found or has no options on "
+            "'Journal Entry Account'. Cannot extend options for party references."
+        )
+        return None
+
+    current_options = ref_type_field.options
+    options_list = [opt.strip() for opt in current_options.split("\n")]
+
+    if all(t in options_list for t in new_types):
+        return None
+
+    for t in new_types:
+        if t not in options_list:
+            options_list.append(t)
+
+    return "\n".join(options_list)


### PR DESCRIPTION
## Summary

- When a bank rule targets a non-Receivable/Payable account (e.g., income account for donation tracking), party info is stored as `reference_type`/`reference_name` on the JE account row instead of `party_type`/`party`
- Avoids ERPNext's `validate_account_party_type` GL validation which rejects party on non-Receivable/Payable accounts
- New `setup.py` extends JE Account `reference_type` field options with Customer/Supplier via Property Setter (runs on `after_install`/`after_migrate`)
- Receivable/Payable accounts continue to use standard `party_type`/`party` fields

## Test plan

- [x] 69 unit tests passing (`bench run-tests --app advanced_bank_reconciliation --module ...test_abr_bank_rule`)
- [x] New E2E test: JE rule with party on income account stores as reference
- [x] New E2E test: JE rule with party on receivable account uses party fields (regression guard)
- [x] Manual test on demo.localhost: created bank transaction + rule mimicking City Impact Church pattern, verified JE created with `reference_type=Customer` on Donations income account
- [ ] Run `bench migrate` on target sites to apply the Property Setter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed handling of customer/supplier information in bank reconciliation rules—party data is now correctly assigned based on account type, preventing validation failures for non-receivable/payable accounts.

* **Tests**
  * Added test coverage for party field handling in Journal Entry rules across different account types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->