### PR TITLE
fix: exclude ABR Bank Rule from company transaction deletion

### DIFF
--- a/advanced_bank_reconciliation/hooks.py
+++ b/advanced_bank_reconciliation/hooks.py
@@ -266,5 +266,7 @@ fixtures = [
     },
 ]
 
+company_data_to_be_ignored = ["ABR Bank Rule"]
+
 # Automatically update python controller files with type annotations for this app.
 export_python_type_annotations = True


### PR DESCRIPTION
## Summary
- Adds `ABR Bank Rule` to `company_data_to_be_ignored` hook so bank reconciliation rules are preserved when using ERPNext's "Delete Company Transactions" feature
- Without this, all ABR Bank Rules for a company are deleted during transaction cleanup, requiring manual recreation

## Test plan
- [ ] Create a Transaction Deletion Record for a company with ABR Bank Rules
- [ ] Verify ABR Bank Rule appears in the "Excluded DocTypes" table
- [ ] Submit and confirm rules are preserved after deletion completes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system configuration to exclude specific data types from company data processing in bank reconciliation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->