### PR TITLE
ci: add GitHub Actions workflow for server tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,114 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+env:
+  FRAPPE_BRANCH: version-15
+
+concurrency:
+  group: ci-${{ github.ref }}-${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    runs-on: self-hosted
+    timeout-minutes: 60
+    if: "!contains(github.event.head_commit.message, 'chore(release):')"
+    name: Server
+
+    services:
+      redis-cache:
+        image: redis:alpine
+        ports:
+          - 13000:6379
+        options: --health-cmd="redis-cli ping" --health-interval=5s --health-timeout=2s --health-retries=3
+      redis-queue:
+        image: redis:alpine
+        ports:
+          - 11000:6379
+        options: --health-cmd="redis-cli ping" --health-interval=5s --health-timeout=2s --health-retries=3
+      mariadb:
+        image: mariadb:11.8
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: --health-cmd="mariadb-admin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@v4
+
+      - name: Clean previous bench
+        run: rm -rf ${{ github.workspace }}/../frappe-bench
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          check-latest: true
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/*requirements.txt', '**/pyproject.toml', '**/setup.py', '**/setup.cfg') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+            ${{ runner.os }}-
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: 'echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT'
+
+      - uses: actions/cache@v4
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install MariaDB Client
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq mariadb-client
+
+      - name: Setup
+        run: |
+          pip install frappe-bench
+          bench init --skip-redis-config-generation --skip-assets --python "$(which python)" --frappe-branch "$FRAPPE_BRANCH" ${{ github.workspace }}/../frappe-bench
+          mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "SET GLOBAL character_set_server = 'utf8mb4'"
+          mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "SET GLOBAL collation_server = 'utf8mb4_unicode_ci'"
+
+      - name: Install
+        working-directory: ${{ github.workspace }}/../frappe-bench
+        run: |
+          bench get-app erpnext --branch "$FRAPPE_BRANCH"
+          bench get-app advanced_bank_reconciliation $GITHUB_WORKSPACE
+          bench setup requirements --dev
+          bench new-site --db-root-password root --admin-password admin test_site
+          bench --site test_site install-app erpnext
+          bench --site test_site install-app advanced_bank_reconciliation
+          bench build
+        env:
+          CI: "Yes"
+
+      - name: Run Tests
+        working-directory: ${{ github.workspace }}/../frappe-bench
+        run: |
+          bench --site test_site set-config allow_tests true
+          bench --site test_site run-tests --app advanced_bank_reconciliation
+        env:
+          TYPE: server


### PR DESCRIPTION
## Summary

Adds a GitHub Actions CI workflow that runs the full app test suite on every push to `main` and every pull request targeting `main`.

Mirrors the pattern from `erpnext_new_zealand_customizations` (Python 3.12, Node 20, MariaDB 11.8, Redis alpine, self-hosted runner) but drops the `payments` dependency since this app only requires `erpnext`.

No linting step included per request.

## What it does

- Spins up MariaDB 11.8 + Redis (cache + queue) as GitHub Actions services
- Initialises a fresh Frappe v15 bench
- Installs `erpnext` (version-15) and this app on a test site
- Enables `allow_tests` and runs `bench run-tests --app advanced_bank_reconciliation`

## Test plan

- [ ] First push to this PR triggers the workflow successfully
- [ ] All existing tests pass on CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established automated testing infrastructure with continuous integration workflow for code quality assurance and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->