### PR TITLE
fix(abr): return unpaid invoices in FIFO order for partial allocation

### DIFF
--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/advance_bank_reconciliation_tool.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/advance_bank_reconciliation_tool.py
@@ -1517,6 +1517,8 @@ def get_unpaid_si_matching_query(exact_match, for_withdrawal=False, from_date=No
 			AND status NOT IN ('Paid', 'Cancelled', 'Credit Note Issued')
 			AND {amount_condition}
 			{date_filter}
+		-- FIFO: same-rank matches cascade to the oldest invoice first, which is
+		-- the standard AR convention and what users expect for partial allocation.
 		ORDER BY posting_date ASC, name ASC
 	"""
 
@@ -1566,6 +1568,8 @@ def get_unpaid_pi_matching_query(exact_match, for_deposit=False, from_date=None,
 			AND status NOT IN ('Paid', 'Cancelled', 'Debit Note Issued')
 			AND {amount_condition}
 			{date_filter}
+		-- FIFO: same-rank matches cascade to the oldest invoice first, which is
+		-- the standard AP convention and what users expect for partial allocation.
 		ORDER BY posting_date ASC, name ASC
 	"""
 

--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/advance_bank_reconciliation_tool.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/advance_bank_reconciliation_tool.py
@@ -1517,7 +1517,7 @@ def get_unpaid_si_matching_query(exact_match, for_withdrawal=False, from_date=No
 			AND status NOT IN ('Paid', 'Cancelled', 'Credit Note Issued')
 			AND {amount_condition}
 			{date_filter}
-		ORDER BY posting_date DESC
+		ORDER BY posting_date ASC, name ASC
 	"""
 
 
@@ -1566,7 +1566,7 @@ def get_unpaid_pi_matching_query(exact_match, for_deposit=False, from_date=None,
 			AND status NOT IN ('Paid', 'Cancelled', 'Debit Note Issued')
 			AND {amount_condition}
 			{date_filter}
-		ORDER BY posting_date DESC
+		ORDER BY posting_date ASC, name ASC
 	"""
 
 

--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/tests/fixtures.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/tests/fixtures.py
@@ -199,6 +199,7 @@ def create_test_sales_invoice(
 	company=TEST_COMPANY,
 	is_return=0,
 	do_not_submit=False,
+	posting_date=None,
 ):
 	"""Create and submit a Sales Invoice with the requested grand total."""
 	item_code = ensure_item()
@@ -206,14 +207,15 @@ def create_test_sales_invoice(
 
 	qty = -1 if is_return else 1
 	rate = abs(flt(outstanding))
+	posting = posting_date or nowdate()
 
 	doc = frappe.get_doc(
 		{
 			"doctype": "Sales Invoice",
 			"customer": customer,
 			"company": company,
-			"posting_date": nowdate(),
-			"due_date": add_days(nowdate(), 30),
+			"posting_date": posting,
+			"due_date": add_days(posting, 30),
 			"currency": currency or frappe.db.get_value("Company", company, "default_currency"),
 			"is_return": 1 if is_return else 0,
 			"update_stock": 0,
@@ -243,18 +245,20 @@ def create_test_purchase_invoice(
 	supplier=None,
 	company=TEST_COMPANY,
 	do_not_submit=False,
+	posting_date=None,
 ):
 	"""Create and submit a Purchase Invoice with the requested grand total."""
 	item_code = ensure_item()
 	supplier = supplier or ensure_supplier()
+	posting = posting_date or nowdate()
 
 	doc = frappe.get_doc(
 		{
 			"doctype": "Purchase Invoice",
 			"supplier": supplier,
 			"company": company,
-			"posting_date": nowdate(),
-			"due_date": add_days(nowdate(), 30),
+			"posting_date": posting,
+			"due_date": add_days(posting, 30),
 			"currency": currency or frappe.db.get_value("Company", company, "default_currency"),
 			"update_stock": 0,
 			"items": [

--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/tests/fixtures.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/tests/fixtures.py
@@ -201,21 +201,26 @@ def create_test_sales_invoice(
 	do_not_submit=False,
 	posting_date=None,
 ):
-	"""Create and submit a Sales Invoice with the requested grand total."""
+	"""Create and submit a Sales Invoice with the requested grand total.
+
+	Insert always uses today's date to dodge ERPNext's due_date / posting
+	validation. If the caller wants a historical posting_date, we rewrite
+	it via db_set after submit so the field reflects the requested date
+	without going through validation again.
+	"""
 	item_code = ensure_item()
 	customer = customer or ensure_customer()
 
 	qty = -1 if is_return else 1
 	rate = abs(flt(outstanding))
-	posting = posting_date or nowdate()
 
 	doc = frappe.get_doc(
 		{
 			"doctype": "Sales Invoice",
 			"customer": customer,
 			"company": company,
-			"posting_date": posting,
-			"due_date": add_days(posting, 30),
+			"posting_date": nowdate(),
+			"due_date": add_days(nowdate(), 30),
 			"currency": currency or frappe.db.get_value("Company", company, "default_currency"),
 			"is_return": 1 if is_return else 0,
 			"update_stock": 0,
@@ -236,6 +241,9 @@ def create_test_sales_invoice(
 	doc.insert(ignore_permissions=True)
 	if not do_not_submit:
 		doc.submit()
+	if posting_date and posting_date != nowdate():
+		doc.db_set("posting_date", posting_date, update_modified=False)
+		doc.reload()
 	return doc
 
 
@@ -247,18 +255,21 @@ def create_test_purchase_invoice(
 	do_not_submit=False,
 	posting_date=None,
 ):
-	"""Create and submit a Purchase Invoice with the requested grand total."""
+	"""Create and submit a Purchase Invoice with the requested grand total.
+
+	Insert always uses today's date; see create_test_sales_invoice for
+	the rationale around historical posting_date handling.
+	"""
 	item_code = ensure_item()
 	supplier = supplier or ensure_supplier()
-	posting = posting_date or nowdate()
 
 	doc = frappe.get_doc(
 		{
 			"doctype": "Purchase Invoice",
 			"supplier": supplier,
 			"company": company,
-			"posting_date": posting,
-			"due_date": add_days(posting, 30),
+			"posting_date": nowdate(),
+			"due_date": add_days(nowdate(), 30),
 			"currency": currency or frappe.db.get_value("Company", company, "default_currency"),
 			"update_stock": 0,
 			"items": [
@@ -279,6 +290,9 @@ def create_test_purchase_invoice(
 	doc.insert(ignore_permissions=True)
 	if not do_not_submit:
 		doc.submit()
+	if posting_date and posting_date != nowdate():
+		doc.db_set("posting_date", posting_date, update_modified=False)
+		doc.reload()
 	return doc
 
 

--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/tests/test_unpaid_invoice_order.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/tests/test_unpaid_invoice_order.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2024, HighFlyer and contributors
+# For license information, please see license.txt
+"""Guards the FIFO ordering invariant on get_unpaid_si_matching_query and
+get_unpaid_pi_matching_query. The matching dialog cascades partial
+allocations in the order these queries return rows, so the order must
+surface the oldest outstanding invoice first.
+"""
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import add_days, nowdate
+
+from advanced_bank_reconciliation.advanced_bank_reconciliation.doctype.advance_bank_reconciliation_tool.advance_bank_reconciliation_tool import (
+	get_unpaid_pi_matching_query,
+	get_unpaid_si_matching_query,
+)
+
+from .fixtures import (
+	TEST_CUSTOMER,
+	TEST_SUPPLIER,
+	create_test_purchase_invoice,
+	create_test_sales_invoice,
+	setup_abr_test_data,
+)
+
+
+class TestUnpaidInvoiceFIFOOrder(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		setup_abr_test_data()
+		frappe.db.commit()
+
+	def _run_query(self, query, party, currency):
+		return frappe.db.sql(
+			query,
+			{
+				"party": party,
+				"amount": 0,
+				"currency": currency,
+				"from_date": None,
+				"to_date": None,
+			},
+		)
+
+	def test_unpaid_sales_invoices_returned_oldest_first(self):
+		oldest = create_test_sales_invoice(outstanding=100, posting_date=add_days(nowdate(), -60))
+		middle = create_test_sales_invoice(outstanding=100, posting_date=add_days(nowdate(), -30))
+		newest = create_test_sales_invoice(outstanding=100, posting_date=nowdate())
+
+		currency = oldest.currency
+		rows = self._run_query(
+			get_unpaid_si_matching_query(exact_match=False),
+			TEST_CUSTOMER,
+			currency,
+		)
+		names = [r[2] for r in rows]
+		pos = {n: names.index(n) for n in (oldest.name, middle.name, newest.name) if n in names}
+		self.assertLess(pos[oldest.name], pos[middle.name])
+		self.assertLess(pos[middle.name], pos[newest.name])
+
+	def test_unpaid_purchase_invoices_returned_oldest_first(self):
+		oldest = create_test_purchase_invoice(outstanding=100, posting_date=add_days(nowdate(), -45))
+		middle = create_test_purchase_invoice(outstanding=100, posting_date=add_days(nowdate(), -20))
+		newest = create_test_purchase_invoice(outstanding=100, posting_date=nowdate())
+
+		currency = oldest.currency
+		rows = self._run_query(
+			get_unpaid_pi_matching_query(exact_match=False, for_deposit=False),
+			TEST_SUPPLIER,
+			currency,
+		)
+		names = [r[2] for r in rows]
+		pos = {n: names.index(n) for n in (oldest.name, middle.name, newest.name) if n in names}
+		self.assertLess(pos[oldest.name], pos[middle.name])
+		self.assertLess(pos[middle.name], pos[newest.name])


### PR DESCRIPTION
## Summary

- Unpaid Sales and Purchase Invoice matching queries ordered by `posting_date DESC`, so the newest open invoice surfaced first in the reconcile dialog.
- Combined with the per-row allocation cap from #72, a bank transaction with multiple selected invoices paid down the newest invoice first and left older ones under-allocated or untouched.
- Switching to `posting_date ASC, name ASC` matches standard AR/AP convention (pay oldest outstanding first) and makes the cascade allocate in age order. `name ASC` breaks ties deterministically for same-day invoices.

Two lines, one file.

## Test plan

- [ ] With two open invoices for the same customer (older + newer) and a deposit smaller than their combined outstanding, the reconcile dialog lists the older invoice first.
- [ ] Selecting both invoices and submitting allocates to the older invoice first; any remainder flows to the newer one.
- [ ] Purchase invoice flow behaves the same for withdrawals.
- [ ] Same-day invoices appear in deterministic order (by `name`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unpaid Sales and Purchase invoices now match in chronological posting order (oldest first) with a deterministic secondary sort to ensure stable, predictable selections when posting dates tie.

* **Tests**
  * Added tests to verify FIFO ordering of unpaid invoices; test helpers enhanced to allow explicit posting dates for deterministic scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->