### PR TITLE
fix(abr): round allocated_amount to field precision in bulk reconcile

### DIFF
--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/tests/test_bulk_reconcile_precision.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/tests/test_bulk_reconcile_precision.py
@@ -39,9 +39,15 @@ class TestBulkReconcilePrecision(FrappeTestCase):
 		"""Regression: an unrounded float from JS arithmetic must round to
 		the field precision before append, so the second save() inside
 		reconcile_vouchers doesn't trip UpdateAfterSubmitError.
+
+		Invoices are created with round outstanding amounts large enough to
+		cover the partial allocations. The float quirk is in the allocation
+		amounts passed to reconcile_vouchers (what the UI sends), not in
+		the invoice totals — which can differ slightly on CI vs local if
+		tax/rounding defaults change grand_total.
 		"""
-		si1 = create_test_sales_invoice(outstanding=649.71)
-		si2 = create_test_sales_invoice(outstanding=110.29)
+		si1 = create_test_sales_invoice(outstanding=1000)
+		si2 = create_test_sales_invoice(outstanding=1000)
 		bt = create_test_bank_transaction(self.bank_account, deposit=760)
 
 		pe1 = create_payment_entry_for_invoice(

--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/tests/test_bulk_reconcile_precision.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/tests/test_bulk_reconcile_precision.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2024, HighFlyer and contributors
+# For license information, please see license.txt
+"""Regression tests for float-precision handling in bulk reconciliation.
+
+A JS client computing "remaining" via subtraction (e.g. 760 - 649.71) can
+send an allocated amount like 110.28999999999996 to reconcile_vouchers.
+The payment_entries child row's allocated_amount must be rounded to the
+field's precision on append; otherwise the second save() inside
+reconcile_vouchers trips UpdateAfterSubmitError — the in-memory value is
+the unrounded float while the DB value is already rounded.
+"""
+import json
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import flt, nowdate
+
+from advanced_bank_reconciliation.advanced_bank_reconciliation.doctype.advance_bank_reconciliation_tool.advance_bank_reconciliation_tool import (
+	reconcile_vouchers,
+)
+
+from .fixtures import (
+	TEST_COMPANY,
+	create_test_bank_transaction,
+	create_test_sales_invoice,
+	setup_abr_test_data,
+)
+
+
+class TestBulkReconcilePrecision(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		cls.bank_account = setup_abr_test_data(TEST_COMPANY)
+		frappe.db.commit()
+
+	def _make_payment_entry(self, si, amount):
+		"""Create and submit a Payment Entry that fully applies to the SI."""
+		from erpnext.accounts.doctype.payment_entry.payment_entry import (
+			get_payment_entry,
+		)
+
+		pe = get_payment_entry("Sales Invoice", si.name)
+		pe.paid_amount = amount
+		pe.received_amount = amount
+		pe.reference_no = "_ABR-TEST-REF"
+		pe.reference_date = nowdate()
+		pe.references = []
+		pe.append(
+			"references",
+			{
+				"reference_doctype": "Sales Invoice",
+				"reference_name": si.name,
+				"allocated_amount": amount,
+			},
+		)
+		pe.setup_party_account_field()
+		pe.set_missing_values()
+		pe.insert(ignore_permissions=True)
+		pe.submit()
+		return pe
+
+	def test_unrounded_float_allocation_does_not_raise(self):
+		"""Regression: an unrounded float from JS arithmetic must round to
+		the field precision before append, so the second save() inside
+		reconcile_vouchers doesn't trip UpdateAfterSubmitError.
+		"""
+		si1 = create_test_sales_invoice(outstanding=649.71)
+		si2 = create_test_sales_invoice(outstanding=110.29)
+		bt = create_test_bank_transaction(self.bank_account, deposit=760)
+
+		pe1 = self._make_payment_entry(si1, 649.71)
+		pe2 = self._make_payment_entry(si2, 110.29)
+
+		# Simulate what the bulk reconciliation UI sends: the second amount
+		# is computed as deposit - first_amount and carries a JS float error.
+		second_amount = 760 - 649.71
+		self.assertNotEqual(second_amount, 110.29)
+		self.assertAlmostEqual(second_amount, 110.29, places=2)
+
+		vouchers = [
+			{"payment_doctype": "Payment Entry", "payment_name": pe1.name, "amount": 649.71},
+			{"payment_doctype": "Payment Entry", "payment_name": pe2.name, "amount": second_amount},
+		]
+
+		reconcile_vouchers(bt.name, json.dumps(vouchers))
+
+		bt.reload()
+		self.assertEqual(flt(bt.allocated_amount), 760.0)
+		self.assertEqual(flt(bt.unallocated_amount), 0.0)
+		self.assertEqual(len(bt.payment_entries), 2)
+		self.assertEqual(flt(bt.payment_entries[1].allocated_amount), 110.29)

--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/tests/test_bulk_reconcile_precision.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/tests/test_bulk_reconcile_precision.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, HighFlyer and contributors
+# Copyright (c) 2026, HighFlyer and contributors
 # For license information, please see license.txt
 """Regression tests for float-precision handling in bulk reconciliation.
 
@@ -13,9 +13,10 @@ import json
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
-from frappe.utils import flt, nowdate
+from frappe.utils import flt
 
 from advanced_bank_reconciliation.advanced_bank_reconciliation.doctype.advance_bank_reconciliation_tool.advance_bank_reconciliation_tool import (
+	create_payment_entry_for_invoice,
 	reconcile_vouchers,
 )
 
@@ -34,32 +35,6 @@ class TestBulkReconcilePrecision(FrappeTestCase):
 		cls.bank_account = setup_abr_test_data(TEST_COMPANY)
 		frappe.db.commit()
 
-	def _make_payment_entry(self, si, amount):
-		"""Create and submit a Payment Entry that fully applies to the SI."""
-		from erpnext.accounts.doctype.payment_entry.payment_entry import (
-			get_payment_entry,
-		)
-
-		pe = get_payment_entry("Sales Invoice", si.name)
-		pe.paid_amount = amount
-		pe.received_amount = amount
-		pe.reference_no = "_ABR-TEST-REF"
-		pe.reference_date = nowdate()
-		pe.references = []
-		pe.append(
-			"references",
-			{
-				"reference_doctype": "Sales Invoice",
-				"reference_name": si.name,
-				"allocated_amount": amount,
-			},
-		)
-		pe.setup_party_account_field()
-		pe.set_missing_values()
-		pe.insert(ignore_permissions=True)
-		pe.submit()
-		return pe
-
 	def test_unrounded_float_allocation_does_not_raise(self):
 		"""Regression: an unrounded float from JS arithmetic must round to
 		the field precision before append, so the second save() inside
@@ -69,8 +44,22 @@ class TestBulkReconcilePrecision(FrappeTestCase):
 		si2 = create_test_sales_invoice(outstanding=110.29)
 		bt = create_test_bank_transaction(self.bank_account, deposit=760)
 
-		pe1 = self._make_payment_entry(si1, 649.71)
-		pe2 = self._make_payment_entry(si2, 110.29)
+		pe1 = create_payment_entry_for_invoice(
+			invoice_doc=si1,
+			bank_transaction=bt,
+			allocated_amount=649.71,
+			payment_type="Receive",
+			party_type="Customer",
+			party=si1.customer,
+		)
+		pe2 = create_payment_entry_for_invoice(
+			invoice_doc=si2,
+			bank_transaction=bt,
+			allocated_amount=110.29,
+			payment_type="Receive",
+			party_type="Customer",
+			party=si2.customer,
+		)
 
 		# Simulate what the bulk reconciliation UI sends: the second amount
 		# is computed as deposit - first_amount and carries a JS float error.
@@ -89,4 +78,8 @@ class TestBulkReconcilePrecision(FrappeTestCase):
 		self.assertEqual(flt(bt.allocated_amount), 760.0)
 		self.assertEqual(flt(bt.unallocated_amount), 0.0)
 		self.assertEqual(len(bt.payment_entries), 2)
-		self.assertEqual(flt(bt.payment_entries[1].allocated_amount), 110.29)
+
+		# Match by payment_entry name so the assertion is independent of row order
+		by_name = {row.payment_entry: row for row in bt.payment_entries}
+		self.assertEqual(flt(by_name[pe1.name].allocated_amount), 649.71)
+		self.assertEqual(flt(by_name[pe2.name].allocated_amount), 110.29)

--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/overrides/bank_transaction.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/overrides/bank_transaction.py
@@ -1,6 +1,8 @@
 import logging
 
 import frappe
+from frappe.utils import flt
+
 from advanced_bank_reconciliation.utils.logger import (
     get_logger,
 )
@@ -181,10 +183,17 @@ class ExtendedBankTransaction(BankTransaction):
                 logger.info(
                     "Voucher: %s being added to bank transaction %s", voucher, self.name
                 )
+                # Round to the child field's precision so the in-memory value
+                # matches what gets persisted. Without this, an unrounded float
+                # (e.g. 110.28999999999996 from JS arithmetic) triggers
+                # UpdateAfterSubmitError on the subsequent save in
+                # reconcile_vouchers, because validate_update_after_submit
+                # compares the unrounded in-memory value against the DB value.
+                precision = self.precision("allocated_amount", "payment_entries")
                 pe = {
                     "payment_document": voucher["payment_doctype"],
                     "payment_entry": voucher["payment_name"],
-                    "allocated_amount": voucher["amount"],
+                    "allocated_amount": flt(voucher["amount"], precision),
                 }
                 self.append("payment_entries", pe)
                 added = True

--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/overrides/bank_transaction.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/overrides/bank_transaction.py
@@ -168,6 +168,14 @@ class ExtendedBankTransaction(BankTransaction):
                 )
             )
 
+        # Round to the child field's precision so the in-memory value matches
+        # what gets persisted. Without this, an unrounded float
+        # (e.g. 110.28999999999996 from JS arithmetic) triggers
+        # UpdateAfterSubmitError on the subsequent save in reconcile_vouchers,
+        # because validate_update_after_submit compares the unrounded
+        # in-memory value against the rounded DB value.
+        allocated_precision = self.precision("allocated_amount", "payment_entries")
+
         added = False
         for voucher in vouchers:
             # Can't add same voucher twice
@@ -183,17 +191,10 @@ class ExtendedBankTransaction(BankTransaction):
                 logger.info(
                     "Voucher: %s being added to bank transaction %s", voucher, self.name
                 )
-                # Round to the child field's precision so the in-memory value
-                # matches what gets persisted. Without this, an unrounded float
-                # (e.g. 110.28999999999996 from JS arithmetic) triggers
-                # UpdateAfterSubmitError on the subsequent save in
-                # reconcile_vouchers, because validate_update_after_submit
-                # compares the unrounded in-memory value against the DB value.
-                precision = self.precision("allocated_amount", "payment_entries")
                 pe = {
                     "payment_document": voucher["payment_doctype"],
                     "payment_entry": voucher["payment_name"],
-                    "allocated_amount": flt(voucher["amount"], precision),
+                    "allocated_amount": flt(voucher["amount"], allocated_precision),
                 }
                 self.append("payment_entries", pe)
                 added = True


### PR DESCRIPTION
## Summary

- Unrounded floats from the bulk reconciliation UI (e.g. `760 - 649.71 = 110.28999999999996`) caused `UpdateAfterSubmitError: Row #2: Not allowed to change Allocated Amount after submission from 110.29 to 110.28999999999996` when reconciling Payment Entries against a submitted Bank Transaction.
- Root cause: `ExtendedBankTransaction.add_payment_entries` appended the row with the raw float and saved internally, persisting `110.29` to the DB after column-precision rounding. The subsequent `save()` inside `reconcile_vouchers` then tripped `validate_update_after_submit`, which compared the unrounded in-memory value against the rounded DB value.
- Fix: round `voucher["amount"]` to the `allocated_amount` field's precision before appending, so the in-memory value matches what gets persisted.

## Test plan

- [x] New regression test `test_bulk_reconcile_precision.py` reproduces the exact production error when the fix is absent and passes with the fix applied
- [x] Verified on a local bench (`bench --site demo.localhost run-tests --module ...`) that the test fails without the override change and passes with it
- [ ] Sanity check on a staging site: bulk-reconcile a deposit against two PEs where the second amount is computed as `deposit - first`

## Notes for reviewer

Worth a follow-up (not in this PR): `add_payment_entries` departs from ERPNext core's pattern of appending with `allocated_amount=0.0` and letting `allocate_payment_entries` compute the real amount from GL. The override passes the amount directly and also calls `self.save()` inside, leading to a double-save in `reconcile_vouchers`. Refactoring to the core pattern would remove the precision-mismatch class of bug entirely, but is broader in scope than this incident fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed floating-point precision when creating payment entries during bulk bank reconciliation so allocation amounts are consistently rounded, preventing allocation mismatches.

* **Tests**
  * Added a regression test that verifies unrounded float allocations reconcile correctly and totals match expected allocated and unallocated amounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->