### PR TITLE
fix(abr): prevent bulk reconcile failure on BTs with no reference

### DIFF
--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/advance_bank_reconciliation_tool.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/advance_bank_reconciliation_tool.py
@@ -1806,6 +1806,11 @@ def process_bulk_reconciliation(bank_transaction_name, invoices, regular_voucher
 	processed = 0
 	failed = 0
 	all_vouchers = []
+	# Keep the first per-invoice failure so we can surface it on the
+	# completion event. The background logger already has the full trace;
+	# the UI toast previously only said "No payment entries were created",
+	# which hides the actual validation reason.
+	first_error = None
 
 	try:
 		validate_selection_against_unallocated_amount = frappe.get_single_value("Advance Bank Reconciliation Settings", "validate_selection_against_unallocated_amount")
@@ -1871,6 +1876,11 @@ def process_bulk_reconciliation(bank_transaction_name, invoices, regular_voucher
 				except Exception as e:
 					logger.exception("Error processing invoice %s: %s", invoice_data.get("name"), str(e))
 					failed += 1
+					if first_error is None:
+						first_error = {
+							"invoice": invoice_data.get("name"),
+							"message": str(e),
+						}
 					continue
 			
 			# Commit this batch
@@ -1957,6 +1967,10 @@ def process_bulk_reconciliation(bank_transaction_name, invoices, regular_voucher
 				bank_transaction=updated_transaction.name
 			)
 		else:
+			if first_error:
+				raise Exception(
+					f"No payment entries were created. First failure on {first_error['invoice']}: {first_error['message']}"
+				)
 			raise Exception("No payment entries were created")
 			
 	except Exception as e:
@@ -2150,8 +2164,15 @@ def create_payment_entry_for_invoice(invoice_doc, bank_transaction, allocated_am
 	# to the caller's allocation. See helper for the full rationale.
 	_normalise_pe_to_target_invoice(payment_entry, invoice_doc, allocated_amount)
 
-	# Set reference details from bank transaction
-	payment_entry.reference_no = bank_transaction.reference_number or bank_transaction.description
+	# Set reference details from bank transaction. Fall back to the Bank
+	# Transaction name when both reference_number and description are empty,
+	# because ERPNext's Payment Entry validation rejects a Bank-type PE with
+	# no reference_no and we'd otherwise fail the whole bulk run.
+	payment_entry.reference_no = (
+		bank_transaction.reference_number
+		or bank_transaction.description
+		or bank_transaction.name
+	)
 	payment_entry.reference_date = bank_transaction.date
 	payment_entry.posting_date = bank_transaction.date
 

--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/tests/test_bank_txn_reference_fallback.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/tests/test_bank_txn_reference_fallback.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2026, HighFlyer and contributors
+# For license information, please see license.txt
+"""Regression test for Bank Transactions with no reference_number or description.
+
+Bank statement imports can produce rows where both `reference_number` and
+`description` are empty. ERPNext's Payment Entry validation rejects a
+Bank-type PE with no `reference_no`, so the whole bulk reconcile run
+previously aborted with a generic "No payment entries were created"
+message. We now fall back to the Bank Transaction name so the PE always
+has a stable, meaningful reference.
+"""
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import flt, nowdate
+
+from advanced_bank_reconciliation.advanced_bank_reconciliation.doctype.advance_bank_reconciliation_tool.advance_bank_reconciliation_tool import (
+	create_payment_entry_for_invoice,
+)
+
+from .fixtures import (
+	TEST_COMPANY,
+	create_test_bank_transaction,
+	create_test_sales_invoice,
+	setup_abr_test_data,
+)
+
+
+def _create_bare_bank_transaction(bank_account, deposit=0, withdrawal=0, reference_number="", description=""):
+	"""Create a Bank Transaction without the fixture's default reference_number
+	fallback. The fixture coerces empty strings to "_ABR-REF" via `or`, which
+	would defeat the point of these tests.
+	"""
+	gl_account = frappe.db.get_value("Bank Account", bank_account, "account")
+	account_currency = frappe.db.get_value("Account", gl_account, "account_currency")
+
+	doc = frappe.get_doc(
+		{
+			"doctype": "Bank Transaction",
+			"date": nowdate(),
+			"bank_account": bank_account,
+			"deposit": flt(deposit),
+			"withdrawal": flt(withdrawal),
+			"reference_number": reference_number,
+			"description": description,
+			"currency": account_currency,
+		}
+	)
+	doc.insert(ignore_permissions=True)
+	doc.submit()
+	return doc
+
+
+class TestBankTxnReferenceFallback(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		cls.bank_account = setup_abr_test_data(TEST_COMPANY)
+		frappe.db.commit()
+
+	def test_fallback_to_bank_transaction_name_when_reference_and_description_empty(self):
+		"""A BT with both reference_number and description empty must still
+		produce a valid PE. The fallback is the Bank Transaction name so
+		the PE remains traceable back to its source.
+		"""
+		si = create_test_sales_invoice(outstanding=500)
+		bt = _create_bare_bank_transaction(
+			self.bank_account,
+			deposit=500,
+			reference_number="",
+			description="",
+		)
+
+		pe = create_payment_entry_for_invoice(
+			invoice_doc=si,
+			bank_transaction=bt,
+			allocated_amount=500,
+			payment_type="Receive",
+			party_type="Customer",
+			party=si.customer,
+		)
+
+		self.assertEqual(pe.reference_no, bt.name)
+
+	def test_reference_number_preferred_over_description_and_name(self):
+		si = create_test_sales_invoice(outstanding=500)
+		bt = create_test_bank_transaction(
+			self.bank_account,
+			deposit=500,
+			reference_number="REF-123",
+			description="Some description",
+		)
+
+		pe = create_payment_entry_for_invoice(
+			invoice_doc=si,
+			bank_transaction=bt,
+			allocated_amount=500,
+			payment_type="Receive",
+			party_type="Customer",
+			party=si.customer,
+		)
+
+		self.assertEqual(pe.reference_no, "REF-123")
+
+	def test_description_used_when_reference_number_empty(self):
+		si = create_test_sales_invoice(outstanding=500)
+		bt = _create_bare_bank_transaction(
+			self.bank_account,
+			deposit=500,
+			reference_number="",
+			description="Stable description",
+		)
+
+		pe = create_payment_entry_for_invoice(
+			invoice_doc=si,
+			bank_transaction=bt,
+			allocated_amount=500,
+			payment_type="Receive",
+			party_type="Customer",
+			party=si.customer,
+		)
+
+		self.assertEqual(pe.reference_no, "Stable description")


### PR DESCRIPTION
## Summary
- Fall back to `Bank Transaction.name` in `create_payment_entry_for_invoice` when both `reference_number` and `description` are empty. Keeps bulk reconcile working for statement imports that produce memo-less rows.
- Capture the first per-invoice failure in `process_bulk_reconciliation` and include it in the completion event so the UI toast shows the real reason instead of the generic "No payment entries were created".

## Root cause
`create_payment_entry_for_invoice` set `payment_entry.reference_no = bank_transaction.reference_number or bank_transaction.description`. When both are empty, `reference_no` ended up empty and ERPNext's `validate_transaction_reference` threw "Reference No and Reference Date is mandatory for Bank transaction" inside the background job. The outer handler then raised "No payment entries were created", which the frontend surfaced to the user as a generic failure toast with no actionable detail.

## Changes
- `advance_bank_reconciliation_tool.py`
  - `create_payment_entry_for_invoice`: reference fallback chain is now `reference_number → description → bank_transaction.name`.
  - `process_bulk_reconciliation`: track first per-invoice error; include it in the exception message when no PEs are created so the frontend toast carries the real reason.
- New regression tests: `tests/test_bank_txn_reference_fallback.py` covering all three fallback cases.

## Test plan
- [x] `bench --site demo.localhost run-tests --module ...test_bank_txn_reference_fallback` passes locally (3/3).
- [ ] CI full test suite.
- [ ] Manual on affected site after deploy: re-run bulk reconcile on an affected Bank Transaction and confirm PEs are created with `reference_no = BT name`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting during bulk bank reconciliation—now captures and displays the first invoice-level exception encountered, providing clearer failure information.
  * Enhanced payment entry creation to properly assign reference numbers from available bank transaction data with intelligent fallback handling, preventing validation rejections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->