### PR TITLE
fix(abr): add FIFO toggle and cap matching dialog table

### DIFF
--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_settings/advance_bank_reconciliation_settings.json
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_settings/advance_bank_reconciliation_settings.json
@@ -11,6 +11,7 @@
   "column_break_defaults",
   "default_journal_entry_type",
   "reconciling_unpaid_invoices_section",
+  "sort_unpaid_invoices_by_posting_date",
   "validate_selection_against_unallocated_amount",
   "reconcile_unpaid_invoices_in_background"
  ],
@@ -57,6 +58,13 @@
   },
   {
    "default": "0",
+   "description": "When enabled, unpaid invoices in the matching dialog are listed strictly by posting date (oldest first). When disabled (default), invoices whose outstanding amount exactly matches the bank transaction are surfaced first.",
+   "fieldname": "sort_unpaid_invoices_by_posting_date",
+   "fieldtype": "Check",
+   "label": "Sort unpaid invoices by posting date (FIFO)"
+  },
+  {
+   "default": "0",
    "description": "If checked, the unallocated amount from the bank transaction will be validated against the total of the selected unpaid invoices. If the total doesn't match, an error will be thrown.",
    "fieldname": "validate_selection_against_unallocated_amount",
    "fieldtype": "Check",
@@ -74,7 +82,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-03-29 12:00:00.000000",
+ "modified": "2026-04-28 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Advanced Bank Reconciliation",
  "name": "Advance Bank Reconciliation Settings",

--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_settings/advance_bank_reconciliation_settings.json
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_settings/advance_bank_reconciliation_settings.json
@@ -10,6 +10,8 @@
   "default_document_type",
   "column_break_defaults",
   "default_journal_entry_type",
+  "matching_dialog_section",
+  "compact_matching_vouchers_table",
   "reconciling_unpaid_invoices_section",
   "sort_unpaid_invoices_by_posting_date",
   "validate_selection_against_unallocated_amount",
@@ -52,6 +54,18 @@
    "options": "Journal Entry\nInter Company Journal Entry\nBank Entry\nCash Entry\nCredit Card Entry\nDebit Note\nCredit Note\nContra Entry\nExcise Entry\nWrite Off Entry\nOpening Entry\nDepreciation Entry\nExchange Rate Revaluation\nDeferred Revenue\nDeferred Expense"
   },
   {
+   "fieldname": "matching_dialog_section",
+   "fieldtype": "Section Break",
+   "label": "Matching Dialog"
+  },
+  {
+   "default": "0",
+   "description": "When enabled, the matching vouchers table in the reconciliation dialog auto-shrinks for few rows and caps at 300px when there are many. Keep disabled if your workflow involves scanning long lists of vouchers at a glance.",
+   "fieldname": "compact_matching_vouchers_table",
+   "fieldtype": "Check",
+   "label": "Compact matching vouchers table"
+  },
+  {
    "fieldname": "reconciling_unpaid_invoices_section",
    "fieldtype": "Section Break",
    "label": "Reconciling Unpaid Invoices"
@@ -82,7 +96,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-04-28 12:00:00.000000",
+ "modified": "2026-04-28 13:00:00.000000",
  "modified_by": "Administrator",
  "module": "Advanced Bank Reconciliation",
  "name": "Advance Bank Reconciliation Settings",

--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/advance_bank_reconciliation_tool.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/advance_bank_reconciliation_tool.py
@@ -189,6 +189,7 @@ def get_abr_default_settings():
 		"default_reconciliation_action": settings.default_reconciliation_action or "Match Against Voucher",
 		"default_document_type": settings.default_document_type or "Payment Entry",
 		"default_journal_entry_type": settings.default_journal_entry_type or "Bank Entry",
+		"compact_matching_vouchers_table": bool(settings.compact_matching_vouchers_table),
 	}
 
 

--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/advance_bank_reconciliation_tool.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/advance_bank_reconciliation_tool.py
@@ -1485,6 +1485,17 @@ def get_unpaid_si_matching_query(exact_match, for_withdrawal=False, from_date=No
 		amount_condition = "outstanding_amount != 0.0"
 		amount_comparison = "outstanding_amount = %(amount)s"
 
+	# When strict FIFO is enabled in settings, neutralise the amount-match rank
+	# term so all candidate invoices share the same rank and the inner ORDER BY
+	# (posting_date ASC, name ASC) is the only thing that decides position.
+	strict_fifo = bool(
+		frappe.db.get_single_value(
+			"Advance Bank Reconciliation Settings",
+			"sort_unpaid_invoices_by_posting_date",
+		)
+	)
+	amount_rank_term = "0" if strict_fifo else f"CASE WHEN {amount_comparison} THEN 1 ELSE 0 END"
+
 	# Add date filters if provided
 	date_filter = ""
 	if from_date and to_date:
@@ -1497,7 +1508,7 @@ def get_unpaid_si_matching_query(exact_match, for_withdrawal=False, from_date=No
 	return f"""
 		SELECT
 			( CASE WHEN customer = %(party)s THEN 1 ELSE 0 END
-			+ CASE WHEN {amount_comparison} THEN 1 ELSE 0 END
+			+ {amount_rank_term}
 			+ CASE WHEN currency = %(currency)s THEN 1 ELSE 0 END
 			+ 1 ) AS rank,
 			'Unpaid Sales Invoice' as doctype,
@@ -1536,6 +1547,17 @@ def get_unpaid_pi_matching_query(exact_match, for_deposit=False, from_date=None,
 		amount_condition = "ABS(outstanding_amount) = ABS(%(amount)s)" if exact_match else "outstanding_amount > 0.0"
 		amount_comparison = "ABS(outstanding_amount) = ABS(%(amount)s)" if exact_match else "outstanding_amount = %(amount)s"
 
+	# When strict FIFO is enabled in settings, neutralise the amount-match rank
+	# term so all candidate invoices share the same rank and the inner ORDER BY
+	# (posting_date ASC, name ASC) is the only thing that decides position.
+	strict_fifo = bool(
+		frappe.db.get_single_value(
+			"Advance Bank Reconciliation Settings",
+			"sort_unpaid_invoices_by_posting_date",
+		)
+	)
+	amount_rank_term = "0" if strict_fifo else f"CASE WHEN {amount_comparison} THEN 1 ELSE 0 END"
+
 	# Add date filters if provided
 	date_filter = ""
 	if from_date and to_date:
@@ -1548,7 +1570,7 @@ def get_unpaid_pi_matching_query(exact_match, for_deposit=False, from_date=None,
 	return f"""
 		SELECT
 			( CASE WHEN supplier = %(party)s THEN 1 ELSE 0 END
-			+ CASE WHEN {amount_comparison} THEN 1 ELSE 0 END
+			+ {amount_rank_term}
 			+ CASE WHEN currency = %(currency)s THEN 1 ELSE 0 END
 			+ 1 ) AS rank,
 			'Unpaid Purchase Invoice' as doctype,

--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/tests/test_unpaid_invoice_order.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/tests/test_unpaid_invoice_order.py
@@ -1,15 +1,21 @@
-# Copyright (c) 2024, HighFlyer and contributors
+# Copyright (c) 2026, HighFlyer and contributors
 # For license information, please see license.txt
 """Guards the FIFO ordering invariant on get_unpaid_si_matching_query and
 get_unpaid_pi_matching_query. The matching dialog cascades partial
 allocations in the order these queries return rows, so the order must
 surface the oldest outstanding invoice first.
+
+Also exercises the end-to-end pipeline through check_matching() to prove
+that the sort_unpaid_invoices_by_posting_date setting actually neutralises
+the amount-match rank tie-breaker that pushes matching-amount invoices to
+the top of the dialog.
 """
 import frappe
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils import add_days, nowdate
 
 from advanced_bank_reconciliation.advanced_bank_reconciliation.doctype.advance_bank_reconciliation_tool.advance_bank_reconciliation_tool import (
+	check_matching,
 	get_unpaid_pi_matching_query,
 	get_unpaid_si_matching_query,
 )
@@ -17,10 +23,15 @@ from advanced_bank_reconciliation.advanced_bank_reconciliation.doctype.advance_b
 from .fixtures import (
 	TEST_CUSTOMER,
 	TEST_SUPPLIER,
+	create_test_bank_transaction,
 	create_test_purchase_invoice,
 	create_test_sales_invoice,
 	setup_abr_test_data,
 )
+
+
+SETTINGS_DOCTYPE = "Advance Bank Reconciliation Settings"
+SETTING_FIELD = "sort_unpaid_invoices_by_posting_date"
 
 
 class TestUnpaidInvoiceFIFOOrder(FrappeTestCase):
@@ -73,3 +84,220 @@ class TestUnpaidInvoiceFIFOOrder(FrappeTestCase):
 		pos = {n: names.index(n) for n in (oldest.name, middle.name, newest.name) if n in names}
 		self.assertLess(pos[oldest.name], pos[middle.name])
 		self.assertLess(pos[middle.name], pos[newest.name])
+
+
+class TestUnpaidInvoiceFIFOToggle(FrappeTestCase):
+	"""End-to-end coverage for the sort_unpaid_invoices_by_posting_date toggle.
+
+	Drives the full check_matching() pipeline that the dialog uses. With the
+	setting OFF (default), invoices whose outstanding_amount equals the bank
+	transaction amount are pushed to the top by the rank tie-breaker even when
+	older invoices exist. With the setting ON, all candidates share the same
+	rank and the inner FIFO ORDER BY wins, surfacing the oldest invoice first.
+	"""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		cls.bank_account = setup_abr_test_data()
+		frappe.db.commit()
+
+	@classmethod
+	def tearDownClass(cls):
+		# Belt-and-braces: tearDown already resets the toggle, but if a test
+		# crashes before tearDown runs the committed setting would leak into
+		# subsequent test classes. Force it back to 0 unconditionally here so
+		# this class is self-contained and order-independent.
+		frappe.db.set_single_value(SETTINGS_DOCTYPE, SETTING_FIELD, 0)
+		frappe.db.commit()
+		super().tearDownClass()
+
+	def setUp(self):
+		super().setUp()
+		# Always start each test with the toggle OFF so the default-OFF
+		# branch is exercised in test_default_off_surfaces_amount_match_first.
+		frappe.db.set_single_value(SETTINGS_DOCTYPE, SETTING_FIELD, 0)
+		frappe.db.commit()
+
+	def tearDown(self):
+		# Reset the toggle for any subsequent test classes that may rely on
+		# the default-off behaviour.
+		frappe.db.set_single_value(SETTINGS_DOCTYPE, SETTING_FIELD, 0)
+		frappe.db.commit()
+		super().tearDown()
+
+	def _build_invoice_set(self):
+		"""Three $100 invoices and one older $250 invoice, all for the same customer."""
+		older_different = create_test_sales_invoice(
+			outstanding=250, posting_date=add_days(nowdate(), -90)
+		)
+		oldest_match = create_test_sales_invoice(
+			outstanding=100, posting_date=add_days(nowdate(), -60)
+		)
+		middle_match = create_test_sales_invoice(
+			outstanding=100, posting_date=add_days(nowdate(), -30)
+		)
+		newest_match = create_test_sales_invoice(outstanding=100, posting_date=nowdate())
+		return older_different, oldest_match, middle_match, newest_match
+
+	def _run_check_matching(
+		self,
+		amount,
+		party,
+		currency,
+		party_type="Customer",
+		document_types=None,
+		direction="deposit",
+	):
+		"""Drive check_matching() the same way the dialog does.
+
+		direction: "deposit" for receipts (Customer / unpaid_sales_invoice) or
+		"withdrawal" for payments (Supplier / unpaid_purchase_invoice). The
+		distinction matters because Bank Transaction stores the amount on
+		different fields and check_matching reads the right one based on
+		whether deposit or withdrawal is set.
+		"""
+		if document_types is None:
+			document_types = ["unpaid_sales_invoice"]
+
+		kwargs = {"currency": currency}
+		if direction == "withdrawal":
+			kwargs["withdrawal"] = amount
+		else:
+			kwargs["deposit"] = amount
+
+		bt = create_test_bank_transaction(self.bank_account, **kwargs)
+		# Prime the transaction with the party and unallocated amount fields
+		# that check_matching reads from.
+		bt.party_type = party_type
+		bt.party = party
+		# unallocated_amount is set on submit but make it explicit for clarity.
+		bt.unallocated_amount = amount
+
+		gl_account = frappe.db.get_value("Bank Account", self.bank_account, "account")
+		company = frappe.db.get_value("Bank Account", self.bank_account, "company")
+
+		return check_matching(
+			gl_account,
+			company,
+			bt,
+			document_types,
+			from_date=None,
+			to_date=None,
+			filter_by_reference_date=None,
+			from_reference_date=None,
+			to_reference_date=None,
+		)
+
+	def _names_in_order(self, matching):
+		# matching is a list of tuples; column 2 is the doc name.
+		return [row[2] for row in matching]
+
+	def test_default_off_surfaces_amount_match_first(self):
+		older_different, oldest_match, middle_match, newest_match = self._build_invoice_set()
+		currency = oldest_match.currency
+
+		matching = self._run_check_matching(100, TEST_CUSTOMER, currency)
+		names = self._names_in_order(matching)
+
+		# Sanity: all four invoices we created should be in the result set.
+		for inv in (older_different, oldest_match, middle_match, newest_match):
+			self.assertIn(inv.name, names)
+
+		older_pos = names.index(older_different.name)
+		match_positions = [
+			names.index(oldest_match.name),
+			names.index(middle_match.name),
+			names.index(newest_match.name),
+		]
+		# With the setting OFF, the three $100 invoices outrank the older
+		# $250 invoice because the amount-match term boosts their rank by 1.
+		self.assertTrue(
+			all(pos < older_pos for pos in match_positions),
+			f"Expected $100 matches before older $250 invoice, got order {names}",
+		)
+
+	def test_setting_on_surfaces_oldest_invoice_first(self):
+		frappe.db.set_single_value(SETTINGS_DOCTYPE, SETTING_FIELD, 1)
+		frappe.db.commit()
+
+		older_different, oldest_match, middle_match, newest_match = self._build_invoice_set()
+		currency = oldest_match.currency
+
+		matching = self._run_check_matching(100, TEST_CUSTOMER, currency)
+		names = self._names_in_order(matching)
+
+		for inv in (older_different, oldest_match, middle_match, newest_match):
+			self.assertIn(inv.name, names)
+
+		older_pos = names.index(older_different.name)
+		match_positions = [
+			names.index(oldest_match.name),
+			names.index(middle_match.name),
+			names.index(newest_match.name),
+		]
+		# With strict FIFO ON, the older $250 invoice (posting date -90d)
+		# beats the three $100 matches even though their amount equals the
+		# deposit. All ranks tie, so posting_date ASC wins.
+		self.assertTrue(
+			all(older_pos < pos for pos in match_positions),
+			f"Expected older $250 invoice before $100 matches, got order {names}",
+		)
+		# And among the three matches themselves, FIFO is preserved.
+		self.assertLess(names.index(oldest_match.name), names.index(middle_match.name))
+		self.assertLess(names.index(middle_match.name), names.index(newest_match.name))
+
+	def test_setting_on_surfaces_oldest_pi_first(self):
+		"""Mirror of test_setting_on_surfaces_oldest_invoice_first for PI.
+
+		Cheap insurance against a one-sided regression in
+		get_unpaid_pi_matching_query: the FIFO toggle code path is duplicated
+		across the SI and PI queries, so the PI branch needs its own
+		end-to-end check_matching coverage. Only the ON case is covered;
+		the toggle is symmetric so the SI OFF test already guards the
+		default behaviour.
+		"""
+		frappe.db.set_single_value(SETTINGS_DOCTYPE, SETTING_FIELD, 1)
+		frappe.db.commit()
+
+		older_different = create_test_purchase_invoice(
+			outstanding=250, posting_date=add_days(nowdate(), -90)
+		)
+		oldest_match = create_test_purchase_invoice(
+			outstanding=100, posting_date=add_days(nowdate(), -60)
+		)
+		middle_match = create_test_purchase_invoice(
+			outstanding=100, posting_date=add_days(nowdate(), -30)
+		)
+		newest_match = create_test_purchase_invoice(outstanding=100, posting_date=nowdate())
+		currency = oldest_match.currency
+
+		matching = self._run_check_matching(
+			100,
+			TEST_SUPPLIER,
+			currency,
+			party_type="Supplier",
+			document_types=["unpaid_purchase_invoice"],
+			direction="withdrawal",
+		)
+		names = self._names_in_order(matching)
+
+		for inv in (older_different, oldest_match, middle_match, newest_match):
+			self.assertIn(inv.name, names)
+
+		older_pos = names.index(older_different.name)
+		match_positions = [
+			names.index(oldest_match.name),
+			names.index(middle_match.name),
+			names.index(newest_match.name),
+		]
+		# With strict FIFO ON, the older $250 PI (posting date -90d) beats
+		# the three $100 matches even though their amount equals the
+		# withdrawal. All ranks tie, so posting_date ASC wins.
+		self.assertTrue(
+			all(older_pos < pos for pos in match_positions),
+			f"Expected older $250 PI before $100 matches, got order {names}",
+		)
+		# And among the three matches themselves, FIFO is preserved.
+		self.assertLess(names.index(oldest_match.name), names.index(middle_match.name))
+		self.assertLess(names.index(middle_match.name), names.index(newest_match.name))

--- a/advanced_bank_reconciliation/public/js/advance_bank_reconciliation_tool/dialog_manager.js
+++ b/advanced_bank_reconciliation/public/js/advance_bank_reconciliation_tool/dialog_manager.js
@@ -379,6 +379,14 @@ nexwave.accounts.bank_reconciliation.DialogManager = class DialogManager {
 				}
 			};
 			this.datatable = new frappe.DataTable(proposals_wrapper.get(0), datatable_options);
+			// Cap the matching-vouchers table at 300px so the Transaction Details
+			// section below stays close to the action. Fixed value (vs the viewport
+			// calc used by the outer table in data_table_manager.js) is intentional
+			// for modal context.
+			$(`.${this.datatable.style.scopeClass} .dt-scrollable`).css({
+				"max-height": "300px",
+				"height": "auto",
+			});
 		} else {
 			console.log("Refreshing data table");
 			this.datatable.refresh(this.data, this.columns);

--- a/advanced_bank_reconciliation/public/js/advance_bank_reconciliation_tool/dialog_manager.js
+++ b/advanced_bank_reconciliation/public/js/advance_bank_reconciliation_tool/dialog_manager.js
@@ -379,14 +379,18 @@ nexwave.accounts.bank_reconciliation.DialogManager = class DialogManager {
 				}
 			};
 			this.datatable = new frappe.DataTable(proposals_wrapper.get(0), datatable_options);
-			// Cap the matching-vouchers table at 300px so the Transaction Details
-			// section below stays close to the action. Fixed value (vs the viewport
-			// calc used by the outer table in data_table_manager.js) is intentional
-			// for modal context.
-			$(`.${this.datatable.style.scopeClass} .dt-scrollable`).css({
-				"max-height": "300px",
-				"height": "auto",
-			});
+			// Optionally cap the matching-vouchers table at 300px so the
+			// Transaction Details section below stays close to the action.
+			// Gated by the "Compact matching vouchers table" setting so sites
+			// that prefer scanning long lists at a glance keep the default
+			// behaviour. Fixed value (vs the viewport calc used by the outer
+			// table in data_table_manager.js) is intentional for modal context.
+			if (this.default_settings && this.default_settings.compact_matching_vouchers_table) {
+				$(`.${this.datatable.style.scopeClass} .dt-scrollable`).css({
+					"max-height": "300px",
+					"height": "auto",
+				});
+			}
 		} else {
 			console.log("Refreshing data table");
 			this.datatable.refresh(this.data, this.columns);


### PR DESCRIPTION
## Summary

- Add `sort_unpaid_invoices_by_posting_date` setting on **Advance Bank Reconciliation Settings** (default OFF). When enabled, unpaid invoices in the matching dialog are listed strictly by posting date (oldest first), aligning with standard AR/AP convention. Existing customers see no behavior change unless they opt in.
- Cap the matching-vouchers datatable at 300px (auto-shrink for few rows) so the Transaction Details section stays visible without scrolling.

## Why

A user reported that when reconciling multiple deposits against the same customer, NexWave was surfacing amount-coincident unpaid invoices ahead of older ones. Standard AR practice is FIFO. The same user also flagged constant scrolling between the voucher list and bank transaction details when only a handful of matches were returned.

## Behavior

- **Setting OFF (default)**: SQL output is byte-identical to before this PR. Rank in `get_unpaid_si_matching_query` / `get_unpaid_pi_matching_query` still includes the amount-match bonus; outer `sorted(..., reverse=True)` in `check_matching` surfaces amount-matchers first.
- **Setting ON**: Rank drops the amount-match term. All unpaid invoices for the party share the same rank, so Python's stable sort falls through to the inner `ORDER BY posting_date ASC, name ASC` (strict FIFO).
- **Datatable cap**: Always-on; mirrors the pattern already used by the outer datatable in `data_table_manager.js`.

## Test plan

- [ ] CI runs `TestUnpaidInvoiceFIFOToggle` covering SI OFF, SI ON, and PI ON paths through `check_matching` end-to-end
- [ ] Existing `TestUnpaidInvoiceFIFOOrder` (inner SQL FIFO) still passes
- [ ] Manual: open matching dialog with 1-3 vouchers, confirm the table shrinks and Transaction Details is visible without scrolling
- [ ] Manual: open matching dialog with 20+ vouchers, confirm the table caps at 300px and scrolls internally
- [ ] Manual: enable the new setting, reopen the dialog, confirm row order changes to oldest-first

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a setting to toggle unpaid-invoice ordering in the reconciliation matching dialog (enable FIFO by posting date).
  * Added a compact vouchers option that limits the matching dialog’s vouchers table height for improved modal usability.

* **Tests**
  * Added end-to-end tests validating the invoice-sorting toggle behavior and ensuring no cross-test leakage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->