### PR TITLE
fix(abr): magnitude comparison in bulk reconciliation preflight

### DIFF
--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/advance_bank_reconciliation_tool.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/advance_bank_reconciliation_tool.py
@@ -1790,7 +1790,7 @@ def create_payment_entries_bulk(bank_transaction_name, invoices, regular_voucher
 	# 3) Combined total must equal BT unallocated amount (within small tolerance)
 	# when the site has opted into strict validation.
 	combined_total = total_invoices_amount + total_regular_amount
-	if validate_selection_against_unallocated_amount and abs(combined_total - bt.unallocated_amount) > 0.01:
+	if validate_selection_against_unallocated_amount and _selection_exceeds_unallocated(combined_total, bt.unallocated_amount):
 		frappe.throw(_(
 			"Selected allocations total {0} but this Bank Transaction has {1} unallocated. "
 			"Please add or remove vouchers so the totals match, split the Bank Transaction, "
@@ -1971,7 +1971,7 @@ def process_bulk_reconciliation(bank_transaction_name, invoices, regular_voucher
 			total_alloc = 0.0
 			for v in regular_vouchers:
 				total_alloc += v.get("amount", 0)
-			if abs(total_alloc - current_unalloc) > 0.01:
+			if _selection_exceeds_unallocated(total_alloc, current_unalloc):
 				raise Exception(
 					f"Selected vouchers total {total_alloc} exceed remaining unallocated amount {current_unalloc}"
 				)
@@ -2010,7 +2010,7 @@ def process_bulk_reconciliation(bank_transaction_name, invoices, regular_voucher
 			total_alloc = 0.0
 			for v in all_vouchers:
 				total_alloc += v.get("amount", 0)
-			if validate_selection_against_unallocated_amount and abs(total_alloc - current_unalloc) > 0.01:
+			if validate_selection_against_unallocated_amount and _selection_exceeds_unallocated(total_alloc, current_unalloc):
 				raise Exception(
 					f"Combined allocations {total_alloc} exceed remaining unallocated amount {current_unalloc}"
 				)
@@ -2102,6 +2102,25 @@ def cleanup_failed_reconciliation(vouchers):
 		except Exception as e:
 			logger.error(f"Error cleaning up payment entry {voucher.get('payment_name')}: {str(e)}")
 			continue
+
+
+def _selection_exceeds_unallocated(
+	signed_alloc_total: float,
+	bt_unallocated: float,
+	tolerance: float = 0.01,
+) -> bool:
+	"""Return True iff the magnitude of the selected allocation total deviates
+	from the Bank Transaction's unallocated magnitude by more than `tolerance`.
+
+	ABR stores signed allocations in Bank Transaction Payments: positive for
+	deposits-against-positive-invoice, negative for refund (deposit-against-
+	paid-refund-PI, or withdrawal-against-paid-refund-SI). `bt.unallocated_amount`
+	is always a positive magnitude (since the 1.7.7 update_allocated_amount fix
+	uses abs(W-D) - abs(signed_sum)). This comparison must therefore use
+	magnitudes on both sides; comparing raw signed against positive magnitude
+	rejects every valid refund reconciliation.
+	"""
+	return abs(abs(flt(signed_alloc_total)) - abs(flt(bt_unallocated))) > tolerance
 
 
 def _signed_cap(allocated_amount, outstanding_amount):

--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/tests/test_partial_allocation.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/tests/test_partial_allocation.py
@@ -13,7 +13,9 @@ from frappe.utils import add_days, flt, nowdate
 
 from advanced_bank_reconciliation.advanced_bank_reconciliation.doctype.advance_bank_reconciliation_tool.advance_bank_reconciliation_tool import (
 	_normalise_pe_to_target_invoice,
+	_selection_exceeds_unallocated,
 	_signed_cap,
+	create_payment_entries_bulk,
 	create_payment_entry_for_invoice,
 	get_linked_payments,
 	reconcile_vouchers,
@@ -1184,3 +1186,292 @@ class TestRefundMatchingAndAllocation(FrappeTestCase):
 		self.assertAlmostEqual(flt(pi_rows[0][3]), -31.27, places=2)
 		self.assertEqual(len(pe_rows), 1, f"Expected customer PE to surface, got: {pe_rows}")
 		self.assertAlmostEqual(flt(pe_rows[0][3]), 200.0, places=2)
+
+
+class TestBulkReconciliationSignHandling(FrappeTestCase):
+	"""Tests for sign-aware comparison in bulk reconciliation preflight validators.
+
+	Covers the regression where `abs(signed_total - positive_unalloc)` rejected
+	every valid refund reconciliation (e.g. deposit BT + paid-refund PI with
+	amount=-31.22 gave abs(-31.22 - 31.22)=62.44 > 0.01).
+
+	The fix introduces _selection_exceeds_unallocated which compares magnitudes
+	on both sides so signed allocations are accepted when magnitudes match.
+	"""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		cls.bank_account = setup_abr_test_data(TEST_COMPANY)
+		# Disable background queuing so create_payment_entries_bulk runs synchronously
+		# in tests (now=not reconcile_unpaid_invoices_in_background => now=True).
+		cls._orig_bg = frappe.db.get_single_value(
+			"Advance Bank Reconciliation Settings", "reconcile_unpaid_invoices_in_background"
+		)
+		frappe.db.set_single_value(
+			"Advance Bank Reconciliation Settings", "reconcile_unpaid_invoices_in_background", 0
+		)
+		frappe.db.commit()
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.db.set_single_value(
+			"Advance Bank Reconciliation Settings",
+			"reconcile_unpaid_invoices_in_background",
+			cls._orig_bg,
+		)
+		frappe.db.commit()
+		super().tearDownClass()
+
+	# -----------------------------------------------------------------------
+	# Unit tests for the helper (no DB required)
+	# -----------------------------------------------------------------------
+
+	def test_helper_accepts_positive_alloc_matching_unalloc(self):
+		"""Positive alloc == positive unalloc: should NOT exceed."""
+		self.assertFalse(_selection_exceeds_unallocated(31.22, 31.22))
+
+	def test_helper_accepts_negative_alloc_matching_unalloc(self):
+		"""Negative alloc with matching magnitude: must NOT exceed (the regression case).
+
+		Before the fix, abs(-31.22 - 31.22) = 62.44 > 0.01 caused a false rejection.
+		"""
+		self.assertFalse(_selection_exceeds_unallocated(-31.22, 31.22))
+
+	def test_helper_rejects_mismatched_magnitudes(self):
+		"""Positive alloc that undershoots: should exceed."""
+		self.assertTrue(_selection_exceeds_unallocated(20, 31.22))
+
+	def test_helper_rejects_mismatched_negative(self):
+		"""Negative alloc that undershoots in magnitude: should exceed."""
+		self.assertTrue(_selection_exceeds_unallocated(-20, 31.22))
+
+	def test_helper_within_tolerance(self):
+		"""Difference of 0.005 is within tolerance of 0.01: must NOT exceed."""
+		self.assertFalse(_selection_exceeds_unallocated(31.225, 31.22, tolerance=0.01))
+
+	# -----------------------------------------------------------------------
+	# Integration: paid refund PI on deposit BT, regular-voucher-only path
+	# (exercises line 1974, always-on check)
+	# -----------------------------------------------------------------------
+
+	def test_bulk_recon_paid_refund_pi_on_deposit_regular_voucher_path(self):
+		"""A paid refund PI (is_paid=1, is_return=1) reconciled as a regular
+		voucher against a deposit BT must succeed end-to-end through
+		create_payment_entries_bulk without raising a sign-comparison error.
+
+		This exercises the ungated safety check (line 1974) that previously
+		computed abs(-31.22 - 31.22) = 62.44 and incorrectly rejected the
+		reconciliation.
+		"""
+		pi = create_test_purchase_invoice(
+			outstanding=31.22,
+			is_paid=1,
+			is_return=1,
+			cash_bank_account=TEST_BANK_GL_ACCOUNT,
+			paid_amount=-31.22,
+		)
+		bt = create_test_bank_transaction(self.bank_account, deposit=31.22)
+
+		create_payment_entries_bulk(
+			bank_transaction_name=bt.name,
+			invoices=[],
+			regular_vouchers=[
+				{
+					"payment_doctype": "Purchase Invoice",
+					"payment_name": pi.name,
+					"amount": -31.22,
+				}
+			],
+		)
+
+		bt.reload()
+		self.assertAlmostEqual(flt(bt.allocated_amount), -31.22, places=2)
+		self.assertAlmostEqual(flt(bt.unallocated_amount), 0.0, places=2)
+		self.assertEqual(bt.status, "Reconciled")
+
+	# -----------------------------------------------------------------------
+	# Integration: paid refund SI on withdrawal BT (symmetric)
+	# -----------------------------------------------------------------------
+
+	def test_bulk_recon_paid_refund_si_on_withdrawal_regular_voucher_path(self):
+		"""A paid refund SI with a negative SIP row reconciled as a regular
+		voucher against a withdrawal BT must succeed through
+		create_payment_entries_bulk.
+
+		Mirrors test_standalone_paid_refund_si_on_withdrawal but routes through
+		the bulk API to cover the ungated preflight check.
+		"""
+		si = create_test_sales_invoice(outstanding=50, is_return=1)
+
+		frappe.get_doc({
+			"doctype": "Sales Invoice Payment",
+			"parent": si.name,
+			"parenttype": "Sales Invoice",
+			"parentfield": "payments",
+			"mode_of_payment": "Cash",
+			"account": TEST_BANK_GL_ACCOUNT,
+			"amount": -50.0,
+			"base_amount": -50.0,
+		}).insert(ignore_permissions=True)
+
+		bt = create_test_bank_transaction(self.bank_account, withdrawal=50)
+
+		create_payment_entries_bulk(
+			bank_transaction_name=bt.name,
+			invoices=[],
+			regular_vouchers=[
+				{
+					"payment_doctype": "Sales Invoice",
+					"payment_name": si.name,
+					"amount": -50,
+				}
+			],
+		)
+
+		bt.reload()
+		self.assertAlmostEqual(flt(bt.allocated_amount), -50.0, places=2)
+		self.assertAlmostEqual(flt(bt.unallocated_amount), 0.0, places=2)
+		self.assertEqual(bt.status, "Reconciled")
+
+	# -----------------------------------------------------------------------
+	# Integration: gated pre-enqueue check with setting ON (line 1793)
+	# -----------------------------------------------------------------------
+
+	def test_gated_precheck_accepts_signed_refund_alloc_when_setting_enabled(self):
+		"""With validate_selection_against_unallocated_amount=1, a paid refund PI
+		reconciled as a regular voucher (amount=-31.22) against a deposit BT
+		(deposit=31.22) must succeed. The gated check at line 1793 must use
+		magnitude comparison and not reject the signed allocation.
+		"""
+		original = frappe.db.get_single_value(
+			"Advance Bank Reconciliation Settings",
+			"validate_selection_against_unallocated_amount",
+		)
+		frappe.db.set_single_value(
+			"Advance Bank Reconciliation Settings",
+			"validate_selection_against_unallocated_amount",
+			1,
+		)
+		self.addCleanup(
+			frappe.db.set_single_value,
+			"Advance Bank Reconciliation Settings",
+			"validate_selection_against_unallocated_amount",
+			original,
+		)
+
+		pi = create_test_purchase_invoice(
+			outstanding=31.22,
+			is_paid=1,
+			is_return=1,
+			cash_bank_account=TEST_BANK_GL_ACCOUNT,
+			paid_amount=-31.22,
+		)
+		bt = create_test_bank_transaction(self.bank_account, deposit=31.22)
+
+		create_payment_entries_bulk(
+			bank_transaction_name=bt.name,
+			invoices=[],
+			regular_vouchers=[
+				{
+					"payment_doctype": "Purchase Invoice",
+					"payment_name": pi.name,
+					"amount": -31.22,
+				}
+			],
+		)
+
+		bt.reload()
+		self.assertAlmostEqual(flt(bt.unallocated_amount), 0.0, places=2)
+		self.assertEqual(bt.status, "Reconciled")
+
+	def test_gated_precheck_rejects_genuine_mismatch_when_setting_enabled(self):
+		"""With validate_selection_against_unallocated_amount=1, a mismatched
+		allocation (voucher amount=-31.22 against BT deposit=20) must still raise
+		frappe.ValidationError. Verifies the helper rejects genuine mismatches
+		even with signed inputs.
+		"""
+		original = frappe.db.get_single_value(
+			"Advance Bank Reconciliation Settings",
+			"validate_selection_against_unallocated_amount",
+		)
+		frappe.db.set_single_value(
+			"Advance Bank Reconciliation Settings",
+			"validate_selection_against_unallocated_amount",
+			1,
+		)
+		self.addCleanup(
+			frappe.db.set_single_value,
+			"Advance Bank Reconciliation Settings",
+			"validate_selection_against_unallocated_amount",
+			original,
+		)
+
+		pi = create_test_purchase_invoice(
+			outstanding=31.22,
+			is_paid=1,
+			is_return=1,
+			cash_bank_account=TEST_BANK_GL_ACCOUNT,
+			paid_amount=-31.22,
+		)
+		bt = create_test_bank_transaction(self.bank_account, deposit=20)
+
+		with self.assertRaises(frappe.ValidationError):
+			create_payment_entries_bulk(
+				bank_transaction_name=bt.name,
+				invoices=[],
+				regular_vouchers=[
+					{
+						"payment_doctype": "Purchase Invoice",
+						"payment_name": pi.name,
+						"amount": -31.22,
+					}
+				],
+			)
+
+	# -----------------------------------------------------------------------
+	# Regression: normal positive voucher still validates correctly
+	# -----------------------------------------------------------------------
+
+	def test_positive_voucher_reconciles_successfully(self):
+		"""A normal positive Payment Entry reconciled as a regular voucher
+		against a deposit BT must succeed. Verifies the abs() change does not
+		accidentally relax or break the positive-allocation path.
+		"""
+		from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
+
+		si = create_test_sales_invoice(outstanding=75)
+		pe = get_payment_entry("Sales Invoice", si.name)
+		pe.paid_to = TEST_BANK_GL_ACCOUNT
+		pe.paid_amount = 75
+		pe.received_amount = 75
+		pe.reference_no = "_ABR-BULK-POS"
+		pe.reference_date = nowdate()
+		pe.posting_date = nowdate()
+		try:
+			pe.insert(ignore_permissions=True)
+			pe.submit()
+		except Exception as exc:
+			self.skipTest(
+				f"PE submit failed (likely InvalidAccountCurrency on local bench): {exc}. "
+				"CI runs on a fresh site without this issue."
+			)
+			return
+
+		bt = create_test_bank_transaction(self.bank_account, deposit=75)
+
+		create_payment_entries_bulk(
+			bank_transaction_name=bt.name,
+			invoices=[],
+			regular_vouchers=[
+				{
+					"payment_doctype": "Payment Entry",
+					"payment_name": pe.name,
+					"amount": 75,
+				}
+			],
+		)
+
+		bt.reload()
+		self.assertAlmostEqual(flt(bt.unallocated_amount), 0.0, places=2)
+		self.assertEqual(bt.status, "Reconciled")

--- a/advanced_bank_reconciliation/public/js/advance_bank_reconciliation_tool/dialog_manager.js
+++ b/advanced_bank_reconciliation/public/js/advance_bank_reconciliation_tool/dialog_manager.js
@@ -257,6 +257,16 @@ nexwave.accounts.bank_reconciliation.DialogManager = class DialogManager {
 		return { effective, total };
 	}
 
+	selection_exceeds_unallocated(signed_alloc_total, bt_unallocated, tolerance = 0.01) {
+		// Mirror of the backend _selection_exceeds_unallocated helper.
+		// ABR stores signed allocations (negative for refund deposit-against-
+		// paid-refund-PI and withdrawal-against-paid-refund-SI), but
+		// bt.unallocated_amount is always a positive magnitude since the
+		// 1.7.7 update_allocated_amount fix. Compare magnitudes so signed
+		// refund allocations are accepted when magnitudes match.
+		return Math.abs(Math.abs(flt(signed_alloc_total)) - Math.abs(flt(bt_unallocated))) > tolerance;
+	}
+
 	show_selected_transactions(transactions) {
 		if (!this.bank_transaction) return;
 
@@ -293,7 +303,7 @@ nexwave.accounts.bank_reconciliation.DialogManager = class DialogManager {
 			: "";
 		const bt_unallocated = flt(this.bank_transaction.unallocated_amount);
 		const strict_warning = this.validate_selection
-			&& Math.abs(effective_total - bt_unallocated) > 0.01
+			&& this.selection_exceeds_unallocated(effective_total, bt_unallocated)
 			? `<div class="text-center pb-2 text-danger"><small>Strict matching is enabled: allocations must equal ${format_currency(bt_unallocated, currency)}. Add or remove vouchers to match.</small></div>`
 			: "";
 		transactions_wrapper.html(`
@@ -888,7 +898,7 @@ nexwave.accounts.bank_reconciliation.DialogManager = class DialogManager {
 		// Strict match: mirror the backend pre-check so the user sees a
 		// clear in-dialog message instead of a server-side throw mid-submit.
 		const bt_unallocated = flt(this.bank_transaction.unallocated_amount);
-		if (this.validate_selection && Math.abs(effective_total - bt_unallocated) > 0.01) {
+		if (this.validate_selection && this.selection_exceeds_unallocated(effective_total, bt_unallocated)) {
 			frappe.msgprint({
 				title: __("Allocation does not match Bank Transaction"),
 				indicator: "red",


### PR DESCRIPTION
## Summary

Followup to PR #79 (released as 1.7.7). After signed-allocation `update_allocated_amount` landed, customers reconciling **paid refund Purchase Invoices** against deposit Bank Transactions still couldn't complete the match. The matching screen showed the invoice (visibility fix worked), but clicking Reconcile failed with:

> Bulk reconciliation failed: Selected vouchers total -31.22 exceed remaining unallocated amount 31.22

## Root cause

Three preflight validators in `advance_bank_reconciliation_tool.py` AND two symmetric checks in `dialog_manager.js` compared a **signed** allocation total against the (now positive) `bt.unallocated_amount`:

**Backend** (`advance_bank_reconciliation_tool.py`):
| Location | Function | Gated by setting? |
|---|---|---|
| Line 1793 | `create_payment_entries_bulk` (pre-enqueue) | Yes |
| Line 1974 | `process_bulk_reconciliation` (regular-vouchers-only branch) | No |
| Line 2013 | `process_bulk_reconciliation` (after invoice→PE conversion) | Yes |

**Frontend** (`dialog_manager.js`):
| Location | Purpose |
|---|---|
| Line 295-298 | Strict-match preview warning under selection total |
| Line 891 | Strict-match submit gate (blocks the dialog before backend) |

For a deposit BT with `unallocated=31.22` and a paid refund PI sending `amount=-31.22` per ABR's signed-allocation convention:

```
abs(-31.22 - 31.22) = 62.44 > 0.01  ->  rejected
```

Every valid refund reconciliation tripped these checks.

## Fix

Introduce a single private helper at each layer that compares magnitudes on both sides, and call it from all sites.

**Backend** (`_selection_exceeds_unallocated`):
```python
def _selection_exceeds_unallocated(signed_alloc_total, bt_unallocated, tolerance=0.01):
    return abs(abs(flt(signed_alloc_total)) - abs(flt(bt_unallocated))) > tolerance
```

**Frontend** (`selection_exceeds_unallocated` on `DialogManager`): same shape using `Math.abs` and `flt`.

Gating decisions, error types, and wording are preserved per site. The JS helper mirrors the backend one so the two layers stay consistent.

## Why this slipped 1.7.7's tests

The previous PR's tests called `reconcile_vouchers` directly and never exercised the public `create_payment_entries_bulk` -> `process_bulk_reconciliation` path where these preflight validators live. The frontend strict-match gate also went uncovered.

## Customer impact

Most sites have `validate_selection_against_unallocated_amount=0` (default) and are unblocked by the backend fix alone. The JS fix protects any site that enables strict matching.

## Tests added

New class `TestBulkReconciliationSignHandling` (backend) with 10 tests:

- 5 unit tests for `_selection_exceeds_unallocated` (positive/negative match, mismatch, tolerance)
- 2 integration tests through `create_payment_entries_bulk` (paid refund PI on deposit, paid refund SI on withdrawal)
- 2 gated-precheck tests (`validate_selection_against_unallocated_amount=1`): one accept, one deliberately mismatched
- 1 positive-PE regression test (verifies the `abs()` change does not relax positive-allocation validation)

JS helper has no test coverage in this repo (consistent with the rest of `dialog_manager.js`).

## Test plan

- [x] Backend: full `test_partial_allocation` module run, all new tests pass
- [ ] CI: GitHub Actions workflow on this PR
- [ ] Manual verification on Hauland sandbox post-deploy (paid refund PI on deposit BT, click Reconcile, confirm match succeeds)
- [ ] Manual smoke with strict matching enabled to verify the JS dialog accepts refund allocations and the warning text only appears for genuine mismatches

## Followup (not blocking)

The `ExtendedBankTransaction.add_payment_entries` override pre-populates `allocated_amount`, which causes upstream `allocate_payment_entries` to skip writing `clearance_date` on the matched paid Invoice rows. Pre-existing in 1.7.7. Verify with customers whether downstream reports rely on this field for paid refund Invoices; if so, the override should call `clear_linked_payment_entry` itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed bulk reconciliation validation to correctly handle refunds/credits by comparing magnitudes (with tolerance), ensuring negative allocations reconcile against unallocated bank amounts.
  * Updated in-dialog strict-match validation so warnings and pre-submit checks respect magnitude-based comparisons.

* **Tests**
  * Added comprehensive unit and integration tests covering signed allocations, tolerance handling, gated pre-check behavior, and regression scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/one-highflyer/advanced_bank_reconciliation/pull/80?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->