### PR TITLE
fix(bank-statement-importer): handle stale and missing column mappings

### DIFF
--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/bank_statement_importer/bank_statement_importer.js
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/bank_statement_importer/bank_statement_importer.js
@@ -89,15 +89,50 @@ frappe.ui.form.on('Bank Statement Importer', {
 				// Apply bank mapping if available
 				const bank_mapping = data?.message?.bank_mapping || {};
 
-				// Extract file field names directly from bank mapping (now bank fields are keys)
-				const dateField = bank_mapping.date;
-				const depositField = bank_mapping.deposit;
-				const withdrawalField = bank_mapping.withdrawal;
-				const descriptionField = bank_mapping.description;
-				const referenceField = bank_mapping.reference_number;
-				const particularsField = bank_mapping.custom_particulars;
-				const codeField = bank_mapping.custom_code;
-				const otherPartyField = bank_mapping.bank_party_name;
+				// Filter saved mapping values against the columns actually present in the uploaded file.
+				// A saved mapping may reference a column name that no longer exists (e.g. the bank
+				// renamed "Reference" to "Reference Number"). Silently filling a Select with an invalid
+				// value causes a ValueError in build_table when .index() is called on the missing column.
+				const headers = data?.message?.header || [];
+				const validInHeaders = (val) => (val && headers.includes(val)) ? val : null;
+
+				// Extract file field names directly from bank mapping, validated against current headers.
+				const dateField = validInHeaders(bank_mapping.date);
+				const depositField = validInHeaders(bank_mapping.deposit);
+				const withdrawalField = validInHeaders(bank_mapping.withdrawal);
+				const descriptionField = validInHeaders(bank_mapping.description);
+				const referenceField = validInHeaders(bank_mapping.reference_number);
+				const particularsField = validInHeaders(bank_mapping.custom_particulars);
+				const codeField = validInHeaders(bank_mapping.custom_code);
+				const otherPartyField = validInHeaders(bank_mapping.bank_party_name);
+
+				// Identify any saved mapping entries that pointed at columns not in the current file.
+				const fieldLabels = {
+					date: __('Date'),
+					deposit: __('Deposit'),
+					withdrawal: __('Withdrawal'),
+					description: __('Description'),
+					reference_number: __('Reference Number'),
+					custom_particulars: __('Particulars'),
+					custom_code: __('Code'),
+					bank_party_name: __('Other Party'),
+				};
+				const staleMappings = [];
+				for (const k of Object.keys(fieldLabels)) {
+					const savedVal = bank_mapping[k];
+					if (savedVal && !headers.includes(savedVal)) {
+						staleMappings.push(`${fieldLabels[k]} (was "${frappe.utils.escape_html(savedVal)}")`);
+					}
+				}
+				if (staleMappings.length > 0) {
+					frappe.msgprint({
+						title: __('Saved field mapping out of date'),
+						indicator: 'yellow',
+						message: __('The saved column mapping for this bank refers to columns that are not in the uploaded file. The following fields were not auto-filled and need to be re-selected:') +
+						'<br><br>' + staleMappings.map(s => `<b>${s}</b>`).join('<br>') + '<br><br>' +
+						__('Pick the correct columns from the dropdowns below, then click Map Fields.')
+					});
+				}
 
 				// Set field options
 				frm.set_df_property("date_select", "options", options);

--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/bank_statement_importer/bank_statement_importer.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/bank_statement_importer/bank_statement_importer.py
@@ -277,6 +277,59 @@ def build_table(mapping, data_headers, data_body):
     currency = account.account_currency
     matching = True
 
+    # Validate that every selected column name is actually present in the uploaded file's
+    # headers before entering the per-row loop. Without this guard, data_headers.index()
+    # raises a bare ValueError that surfaces as an unhandled 500.
+    # Each tuple: (value, label, is_required)
+    fields_to_validate = [
+        (mapping.get("date_select"), _("Date"), True),
+        (mapping.get("description_select"), _("Description"), True),
+        (mapping.get("reference_number_select"), _("Reference Number"), True),
+    ]
+    if is_truthy(mapping.get("same_amount_field")):
+        fields_to_validate.append((mapping.get("amount_select"), _("Amount"), True))
+    else:
+        fields_to_validate.append((mapping.get("deposit_select"), _("Deposit"), True))
+        fields_to_validate.append((mapping.get("withdrawal_select"), _("Withdrawal"), True))
+    # Optional fields: only validate when the user actually picked a value.
+    for select_key, label in (
+        ("particulars_select", _("Particulars")),
+        ("code_select", _("Code")),
+        ("other_party_select", _("Other Party")),
+    ):
+        val = mapping.get(select_key)
+        if val:
+            fields_to_validate.append((val, label, False))
+
+    # Pass A: required fields that are blank/missing.
+    # Pass B: non-empty values that are not present in the file headers.
+    missing_required = []
+    missing = []
+    for value, label, is_required in fields_to_validate:
+        if not value:
+            if is_required:
+                missing_required.append(str(label))
+        elif value not in data_headers:
+            missing.append(f"'{value}' (selected for {label})")
+
+    if missing_required or missing:
+        parts = []
+        if missing_required:
+            parts.append(
+                _("Please select a column for: {0}.").format(", ".join(missing_required))
+            )
+        if missing:
+            parts.append(
+                _(
+                    "The following selected columns are not present in the uploaded file: {0}."
+                ).format(", ".join(missing))
+            )
+        parts.append(_("Re-pick the correct columns from the dropdowns above and click Map Fields again."))
+        frappe.throw(
+            " ".join(parts),
+            title=_("Column Mapping Error"),
+        )
+
     for data_row in data_body:
         # Skip empty rows
         if not data_row or all(cell is None or cell == "" for cell in data_row):


### PR DESCRIPTION
## Summary

When a Bank's saved `bank_transaction_mapping` references a column name that no longer exists in the uploaded CSV (for instance when a bank renames a column between statement formats), the Bank Statement Importer silently fills the Select dropdowns with the stale values and crashes later at "Map Fields" with:

```
ValueError: 'X' is not in list
```

Root cause: Frappe's `frm.set_value` does not validate Select values against the field's `options` list, so the form happily holds an invalid column name until `data_headers.index(...)` blows up server-side.

## Changes

**`bank_statement_importer.js` (upload_statement callback)**
- New `validInHeaders(val)` helper returns `val` only when it appears in the current CSV header array; otherwise `null`.
- All eight `*Field` extractions from `bank_mapping` are wrapped in `validInHeaders(...)`, so stale entries become `null` and existing `if (field)` guards skip the `frm.set_value` calls. Affected dropdowns are left blank.
- `isSameAmountField` runs on the filtered values, so same-amount mode won't activate from a stale mapping.
- One `frappe.msgprint` (yellow indicator) lists any stale entries with their old column names so the user knows to re-pick. `frappe.utils.escape_html` is applied to the user-supplied value.

**`bank_statement_importer.py` (build_table)**
- Validator pass before the per-row loop checks every selected `*_select` against `data_headers`.
- Distinguishes required (date/description/reference_number plus deposit+withdrawal OR amount based on `same_amount_field`) from optional (particulars/code/other_party).
- One consolidated `frappe.throw` covers both:
  1. Required fields with no selection (`"Please select a column for: ..."`)
  2. Selections that aren't in the file (`"The following selected columns are not present in the uploaded file: ..."`)
- Existing per-row defensive guards on optional fields stay in place.

## Before / After

**Before:** User uploads a CSV where one or more bank-statement columns have been renamed → dropdowns silently auto-fill with stale values → click Map Fields → bare `ValueError` 500.

**After:** User uploads the new CSV → yellow msgprint lists the stale entries with their old column names and tells the user to re-pick → affected dropdowns blank → user picks correct columns → Map Fields succeeds. If they skip the warning and click Map Fields anyway, they get a clear "Please select a column for: <field>" error instead of a stack trace.

## Test plan

- [ ] Bank with fully valid saved mapping → no msgprint, dropdowns auto-fill, Map Fields succeeds.
- [ ] Bank with one stale column → msgprint lists it, affected dropdown blank, Map Fields succeeds after user re-picks.
- [ ] Bank with multiple stale columns → one msgprint lists all of them.
- [ ] Bank with `same_amount_field=True` and stale `amount` column → same-amount mode does not activate; user re-picks.
- [ ] User clicks Map Fields without re-picking → friendly consolidated error, no 500.
- [ ] Fresh Bank with no saved mapping → no msgprint, dropdowns blank, user picks manually.

## Scope

No DocType JSON changes. No schema changes. No data migration. Existing happy-path imports are unaffected. The fix is a `fix(...)` patch release.