### PR TITLE
fix(abr): filter unpaid invoice matching queries by bank account's company

### DIFF
--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/advance_bank_reconciliation_tool.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/advance_bank_reconciliation_tool.py
@@ -951,6 +951,7 @@ def check_matching(
 		"party_type": transaction.party_type,
 		"party": transaction.party,
 		"bank_account": bank_account,
+		"company": company,
 		"currency": transaction.currency,
 		"from_date": from_date,
 		"to_date": to_date,
@@ -1063,12 +1064,12 @@ def get_matching_queries(
 	# For deposits, show ALL unpaid sales invoices (both normal and returns)
 	# This allows matching both customer payments (positive) and refunds (negative)
 	if transaction.deposit > 0.0 and "unpaid_sales_invoice" in document_types:
-		query = get_unpaid_si_matching_query(exact_match, for_withdrawal=False, from_date=from_date, to_date=to_date)
+		query = get_unpaid_si_matching_query(exact_match, company, for_withdrawal=False, from_date=from_date, to_date=to_date)
 		queries.append(query)
 
 	# Also check for negative unpaid purchase invoices (returns) for deposits
 	if transaction.deposit > 0.0 and "unpaid_purchase_invoice" in document_types:
-		query = get_unpaid_pi_matching_query(exact_match, for_deposit=True, from_date=from_date, to_date=to_date)
+		query = get_unpaid_pi_matching_query(exact_match, company, for_deposit=True, from_date=from_date, to_date=to_date)
 		queries.append(query)
 
 	# Match paid refund purchase invoices (is_paid=1, paid_amount<0) against deposit transactions
@@ -1082,13 +1083,13 @@ def get_matching_queries(
 			queries.append(query)
 
 		if "unpaid_purchase_invoice" in document_types:
-			query = get_unpaid_pi_matching_query(exact_match, for_deposit=False, from_date=from_date, to_date=to_date)
+			query = get_unpaid_pi_matching_query(exact_match, company, for_deposit=False, from_date=from_date, to_date=to_date)
 			queries.append(query)
 
 		# For withdrawals, show ALL unpaid sales invoices (both normal and returns)
 		# This allows matching both customer refunds (negative) and returned payments (positive)
 		if "unpaid_sales_invoice" in document_types:
-			query = get_unpaid_si_matching_query(exact_match, for_withdrawal=False, from_date=from_date, to_date=to_date)
+			query = get_unpaid_si_matching_query(exact_match, company, for_withdrawal=False, from_date=from_date, to_date=to_date)
 			queries.append(query)
 
 		# Match paid refund sales invoices (is_paid=1, sip.amount<0) against withdrawal transactions
@@ -1510,7 +1511,7 @@ def get_pi_matching_query(exact_match, for_deposit=False):
 	"""
 
 
-def get_unpaid_si_matching_query(exact_match, for_withdrawal=False, from_date=None, to_date=None):
+def get_unpaid_si_matching_query(exact_match, company=None, for_withdrawal=False, from_date=None, to_date=None):
 	# get matching unpaid sales invoice query
 	# Show both normal invoices (positive outstanding) and returns (negative outstanding)
 	# This allows matching both customer payments and refunds in the same view
@@ -1564,6 +1565,7 @@ def get_unpaid_si_matching_query(exact_match, for_withdrawal=False, from_date=No
 			`tabSales Invoice`
 		WHERE
 			docstatus = 1
+			{'AND company = %(company)s' if company else ''}
 			AND status NOT IN ('Paid', 'Cancelled', 'Credit Note Issued')
 			AND {amount_condition}
 			{date_filter}
@@ -1573,7 +1575,7 @@ def get_unpaid_si_matching_query(exact_match, for_withdrawal=False, from_date=No
 	"""
 
 
-def get_unpaid_pi_matching_query(exact_match, for_deposit=False, from_date=None, to_date=None):
+def get_unpaid_pi_matching_query(exact_match, company=None, for_deposit=False, from_date=None, to_date=None):
 	# get matching unpaid purchase invoice query
 	# for_deposit=True is used to match negative invoices (returns) with deposit transactions
 	if for_deposit:
@@ -1626,6 +1628,7 @@ def get_unpaid_pi_matching_query(exact_match, for_deposit=False, from_date=None,
 			`tabPurchase Invoice`
 		WHERE
 			docstatus = 1
+			{'AND company = %(company)s' if company else ''}
 			AND status NOT IN ('Paid', 'Cancelled', 'Debit Note Issued')
 			AND {amount_condition}
 			{date_filter}

--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/tests/fixtures.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/tests/fixtures.py
@@ -77,13 +77,19 @@ def ensure_bank_and_bank_account(company=TEST_COMPANY):
 
 
 def ensure_fiscal_year_for_company(company):
-	"""Link the company to an existing fiscal year that covers today.
+	"""Ensure a fiscal year exists for today and is usable by the given company.
 
-	On ERPNext test sites the global fiscal years are created by the
-	erpnext before_tests hook, but the Fiscal Year Company links are only
-	written for the primary _Test Company. When tests create invoices for
-	a second company, ERPNext's get_fiscal_years() raises FiscalYearError
-	unless the company also appears in the fiscal year's companies list.
+	On a fresh CI site, ERPNext's before_tests hook seeds some fiscal years
+	but not necessarily one that covers today's date (the bench15 demo site
+	has dozens of pre-loaded _Test Fiscal Year XXXX records from earlier
+	test runs; CI does not). When today falls outside every active FY,
+	submitting any invoice fails with FiscalYearError.
+
+	This helper creates a current-year FY if none covers today, then makes
+	sure the company is allowed to use it. A Fiscal Year with no Fiscal
+	Year Company rows is global (any company can use it); once a row is
+	appended it becomes restrictive to the listed companies only, so we
+	leave globally-scoped FYs alone.
 	"""
 	from frappe.utils import getdate
 
@@ -98,12 +104,25 @@ def ensure_fiscal_year_for_company(company):
 		"name",
 	)
 	if not fy:
+		fy_name = f"_ABR Test FY {today.year}"
+		if not frappe.db.exists("Fiscal Year", fy_name):
+			frappe.get_doc(
+				{
+					"doctype": "Fiscal Year",
+					"year": fy_name,
+					"year_start_date": getdate(f"{today.year}-01-01"),
+					"year_end_date": getdate(f"{today.year}-12-31"),
+				}
+			).insert(ignore_permissions=True, ignore_if_duplicate=True)
+		fy = fy_name
+
+	linked_companies = frappe.get_all(
+		"Fiscal Year Company", filters={"parent": fy}, pluck="company"
+	)
+	if not linked_companies:
 		return
 
-	already_linked = frappe.db.exists(
-		"Fiscal Year Company", {"parent": fy, "company": company}
-	)
-	if already_linked:
+	if company in linked_companies:
 		return
 
 	fy_doc = frappe.get_doc("Fiscal Year", fy)
@@ -226,6 +245,7 @@ def ensure_erpnext_test_company():
 def setup_abr_test_data(company=TEST_COMPANY):
 	"""Idempotent top-level setup. Call from setUpClass and commit after."""
 	ensure_erpnext_test_company()
+	ensure_fiscal_year_for_company(company)
 	ensure_customer()
 	ensure_supplier()
 	ensure_item()

--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/tests/fixtures.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/tests/fixtures.py
@@ -10,6 +10,7 @@ import frappe
 from frappe.utils import add_days, flt, nowdate
 
 TEST_COMPANY = "_Test Company"
+TEST_COMPANY_2 = "_Test Company 1"
 TEST_BANK = "_ABR Test Bank"
 TEST_BANK_ACCOUNT_NAME = "_ABR Test Bank Account"
 TEST_BANK_GL_ACCOUNT = "_ABR Test Bank Account - _TC"
@@ -65,6 +66,89 @@ def ensure_bank_and_bank_account(company=TEST_COMPANY):
 				"account_name": TEST_BANK_ACCOUNT_NAME,
 				"bank": TEST_BANK,
 				"account": TEST_BANK_GL_ACCOUNT,
+				"is_company_account": 1,
+				"company": company,
+			}
+		)
+		ba.insert(ignore_permissions=True, ignore_if_duplicate=True)
+		ba_name = ba.name
+
+	return ba_name
+
+
+def ensure_fiscal_year_for_company(company):
+	"""Link the company to an existing fiscal year that covers today.
+
+	On ERPNext test sites the global fiscal years are created by the
+	erpnext before_tests hook, but the Fiscal Year Company links are only
+	written for the primary _Test Company. When tests create invoices for
+	a second company, ERPNext's get_fiscal_years() raises FiscalYearError
+	unless the company also appears in the fiscal year's companies list.
+	"""
+	from frappe.utils import getdate
+
+	today = getdate()
+	fy = frappe.db.get_value(
+		"Fiscal Year",
+		{
+			"year_start_date": ["<=", today],
+			"year_end_date": [">=", today],
+			"disabled": 0,
+		},
+		"name",
+	)
+	if not fy:
+		return
+
+	already_linked = frappe.db.exists(
+		"Fiscal Year Company", {"parent": fy, "company": company}
+	)
+	if already_linked:
+		return
+
+	fy_doc = frappe.get_doc("Fiscal Year", fy)
+	fy_doc.append("companies", {"company": company})
+	fy_doc.save(ignore_permissions=True)
+
+
+def ensure_bank_account_for_company(company):
+	"""Create a bank GL account and Bank Account doc for the given company.
+
+	Uses the company's abbreviation to build unique names so each company
+	in a multi-company test site gets its own isolated bank account.
+	Returns the Bank Account document name.
+	"""
+	ensure_fiscal_year_for_company(company)
+	abbr = frappe.db.get_value("Company", company, "abbr")
+	acct_name = f"_ABR Test Bank Account {abbr}"
+	gl_account_name = f"{acct_name} - {abbr}"
+
+	if not frappe.db.exists("Bank", TEST_BANK):
+		frappe.get_doc({"doctype": "Bank", "bank_name": TEST_BANK}).insert(
+			ignore_permissions=True, ignore_if_duplicate=True
+		)
+
+	if not frappe.db.exists("Account", gl_account_name):
+		parent = _get_parent_bank_account(company)
+		frappe.get_doc(
+			{
+				"doctype": "Account",
+				"account_name": acct_name,
+				"parent_account": parent,
+				"company": company,
+				"account_type": "Bank",
+				"is_group": 0,
+			}
+		).insert(ignore_permissions=True, ignore_if_duplicate=True)
+
+	ba_name = f"{acct_name} - {TEST_BANK}"
+	if not frappe.db.exists("Bank Account", ba_name):
+		ba = frappe.get_doc(
+			{
+				"doctype": "Bank Account",
+				"account_name": acct_name,
+				"bank": TEST_BANK,
+				"account": gl_account_name,
 				"is_company_account": 1,
 				"company": company,
 			}

--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/tests/test_company_isolation.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/tests/test_company_isolation.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2026, HighFlyer and contributors
+# For license information, please see license.txt
+"""Regression tests for company-scoped unpaid-invoice matching.
+
+On multi-company sites the voucher-matching dialog must only return unpaid
+Sales Invoices and unpaid Purchase Invoices that belong to the company
+owning the bank account being reconciled. These tests verify:
+
+  - Company B invoices do NOT surface when reconciling Company A's bank
+    account (the bug that was fixed).
+  - Company A invoices DO surface when reconciling Company A's bank account
+    (happy-path regression guard).
+"""
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import nowdate
+
+from advanced_bank_reconciliation.advanced_bank_reconciliation.doctype.advance_bank_reconciliation_tool.advance_bank_reconciliation_tool import (
+	check_matching,
+)
+
+from .fixtures import (
+	TEST_COMPANY,
+	TEST_COMPANY_2,
+	TEST_CUSTOMER,
+	TEST_SUPPLIER,
+	create_test_bank_transaction,
+	create_test_purchase_invoice,
+	create_test_sales_invoice,
+	ensure_bank_account_for_company,
+	setup_abr_test_data,
+)
+
+
+class TestCompanyIsolation(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		# Set up Company A (primary): bank account, customer, supplier, item
+		cls.bank_account_a = setup_abr_test_data(company=TEST_COMPANY)
+		# Set up Company B: only the bank infrastructure is needed; customer,
+		# supplier, and item are shared across companies in ERPNext
+		cls.bank_account_b = ensure_bank_account_for_company(TEST_COMPANY_2)
+		frappe.db.commit()
+
+	def _run_check_matching(self, bank_account, amount, direction, document_types):
+		"""Run check_matching() the same way the reconciliation dialog does."""
+		kwargs = {}
+		if direction == "deposit":
+			kwargs["deposit"] = amount
+		else:
+			kwargs["withdrawal"] = amount
+
+		bt = create_test_bank_transaction(bank_account, **kwargs)
+		bt.party_type = "Customer" if direction == "deposit" else "Supplier"
+		bt.party = TEST_CUSTOMER if direction == "deposit" else TEST_SUPPLIER
+		bt.unallocated_amount = amount
+
+		gl_account = frappe.db.get_value("Bank Account", bank_account, "account")
+		company = frappe.db.get_value("Bank Account", bank_account, "company")
+
+		return check_matching(
+			gl_account,
+			company,
+			bt,
+			document_types,
+			from_date=None,
+			to_date=None,
+			filter_by_reference_date=None,
+			from_reference_date=None,
+			to_reference_date=None,
+		)
+
+	def _invoice_names(self, matching):
+		return [row[2] for row in matching]
+
+	# --- isolation tests (the bug) ---
+
+	def test_unpaid_pi_company_isolation(self):
+		"""Unpaid PI from Company B must not appear when reconciling Company A's bank account."""
+		pi_company_a = create_test_purchase_invoice(outstanding=200.0, company=TEST_COMPANY)
+		pi_company_b = create_test_purchase_invoice(outstanding=200.0, company=TEST_COMPANY_2)
+
+		matching = self._run_check_matching(
+			self.bank_account_a,
+			amount=200.0,
+			direction="withdrawal",
+			document_types=["unpaid_purchase_invoice"],
+		)
+		names = self._invoice_names(matching)
+
+		self.assertIn(pi_company_a.name, names, "Company A PI should be in results")
+		self.assertNotIn(pi_company_b.name, names, "Company B PI must not appear for Company A reconciliation")
+
+	def test_unpaid_si_company_isolation(self):
+		"""Unpaid SI from Company B must not appear when reconciling Company A's bank account."""
+		si_company_a = create_test_sales_invoice(outstanding=200.0, company=TEST_COMPANY)
+		si_company_b = create_test_sales_invoice(outstanding=200.0, company=TEST_COMPANY_2)
+
+		matching = self._run_check_matching(
+			self.bank_account_a,
+			amount=200.0,
+			direction="deposit",
+			document_types=["unpaid_sales_invoice"],
+		)
+		names = self._invoice_names(matching)
+
+		self.assertIn(si_company_a.name, names, "Company A SI should be in results")
+		self.assertNotIn(si_company_b.name, names, "Company B SI must not appear for Company A reconciliation")
+
+	# --- happy-path regression guards ---
+
+	def test_unpaid_pi_same_company_still_matches(self):
+		"""Unpaid PI belonging to Company A is returned when reconciling Company A's bank account."""
+		pi = create_test_purchase_invoice(outstanding=175.0, company=TEST_COMPANY)
+
+		matching = self._run_check_matching(
+			self.bank_account_a,
+			amount=175.0,
+			direction="withdrawal",
+			document_types=["unpaid_purchase_invoice"],
+		)
+		names = self._invoice_names(matching)
+
+		self.assertIn(pi.name, names, "Company A PI must appear for Company A reconciliation")
+
+	def test_unpaid_si_same_company_still_matches(self):
+		"""Unpaid SI belonging to Company A is returned when reconciling Company A's bank account."""
+		si = create_test_sales_invoice(outstanding=175.0, company=TEST_COMPANY)
+
+		matching = self._run_check_matching(
+			self.bank_account_a,
+			amount=175.0,
+			direction="deposit",
+			document_types=["unpaid_sales_invoice"],
+		)
+		names = self._invoice_names(matching)
+
+		self.assertIn(si.name, names, "Company A SI must appear for Company A reconciliation")

--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/tests/test_company_isolation.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/tests/test_company_isolation.py
@@ -13,7 +13,6 @@ owning the bank account being reconciled. These tests verify:
 """
 import frappe
 from frappe.tests.utils import FrappeTestCase
-from frappe.utils import nowdate
 
 from advanced_bank_reconciliation.advanced_bank_reconciliation.doctype.advance_bank_reconciliation_tool.advance_bank_reconciliation_tool import (
 	check_matching,


### PR DESCRIPTION
## Summary

On multi-company sites, the bank reconciliation tool's voucher-matching dialog returned unpaid Sales Invoices and unpaid Purchase Invoices from every company in the database, not just the company that owns the bank account being reconciled.

The paid-variant queries (Payment Entry, Journal Entry, paid Sales Invoice, paid Purchase Invoice, Bank Transaction) already filter implicitly by bank account, which carries a single company. The two unpaid-invoice queries (`get_unpaid_si_matching_query`, `get_unpaid_pi_matching_query`) had no equivalent filter -- they only constrained by amount, status, and date.

## Fix

- Add an explicit `AND company = %(company)s` clause to both unpaid-invoice queries.
- Add a `company` parameter to both query builders and pass it through from `get_matching_queries` (the company is already resolved from the bank account in `get_linked_payments` and threaded down to `check_matching`).
- Add `"company": company` to the `filters` dict in `check_matching` so the parameter is bound when the SQL runs.

Paid-variant queries are left unchanged -- their existing bank-account filter is already company-safe.

## Test plan

- [x] New test module `test_company_isolation.py` covering:
  - Unpaid PI in Company B does NOT surface when reconciling Company A's bank transaction.
  - Unpaid SI in Company B does NOT surface when reconciling Company A's bank transaction.
  - Unpaid PI in Company A DOES surface when reconciling Company A's bank transaction (happy path regression guard).
  - Unpaid SI in Company A DOES surface when reconciling Company A's bank transaction (happy path regression guard).
- [x] Existing `test_unpaid_invoice_order` suite passes (no regressions in FIFO ordering or amount-match rank logic).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bank reconciliation matching now scopes unpaid sales and purchase invoices by company, preventing cross-company matches and improving accuracy for multi-company accounts.

* **Tests**
  * Added regression tests covering company isolation for deposit/withdrawal reconciliation scenarios.
  * Added idempotent test fixtures/helpers to provision fiscal years, bank records, and company-scoped accounts to reliably support multi-company test setups.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/one-highflyer/advanced_bank_reconciliation/pull/82?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->