### PR TITLE
fix: allow party references in journal entry picker

### DIFF
--- a/advanced_bank_reconciliation/hooks.py
+++ b/advanced_bank_reconciliation/hooks.py
@@ -28,7 +28,9 @@ app_license = "gpl-3.0"
 # page_js = {"page" : "public/js/file.js"}
 
 # include js in doctype views
-# doctype_js = {"doctype" : "public/js/doctype.js"}
+doctype_js = {
+    "Journal Entry": "public/js/journal_entry_reference_query.js",
+}
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}
 # doctype_calendar_js = {"doctype" : "public/js/doctype_calendar.js"}

--- a/advanced_bank_reconciliation/public/js/journal_entry_reference_query.js
+++ b/advanced_bank_reconciliation/public/js/journal_entry_reference_query.js
@@ -1,0 +1,37 @@
+(() => {
+	const party_reference_types = ["Customer", "Supplier", "Employee"];
+	const control_link = frappe.ui.form.ControlLink;
+
+	if (!control_link || control_link.prototype.__abr_party_reference_query_patched) {
+		return;
+	}
+
+	const standard_set_custom_query = control_link.prototype.set_custom_query;
+
+	control_link.prototype.set_custom_query = function (args) {
+		standard_set_custom_query.call(this, args);
+
+		const is_journal_entry_reference =
+			this.frm &&
+			this.frm.doctype === "Journal Entry" &&
+			this.df &&
+			this.df.fieldname === "reference_name" &&
+			(this.doctype === "Journal Entry Account" ||
+				this.df.parent === "Journal Entry Account");
+
+		if (!is_journal_entry_reference) {
+			return;
+		}
+
+		const row =
+			this.doc ||
+			(this.doctype && this.docname ? frappe.get_doc(this.doctype, this.docname) : null);
+
+		if (row && party_reference_types.includes(row.reference_type)) {
+			args.filters = {};
+			delete args.query;
+		}
+	};
+
+	control_link.prototype.__abr_party_reference_query_patched = true;
+})();

--- a/advanced_bank_reconciliation/public/js/journal_entry_reference_query.js
+++ b/advanced_bank_reconciliation/public/js/journal_entry_reference_query.js
@@ -1,4 +1,5 @@
 (() => {
+	// Party doctypes are not submitted, so ERPNext's default docstatus filter hides them.
 	const party_reference_types = ["Customer", "Supplier", "Employee"];
 	const control_link = frappe.ui.form.ControlLink;
 

--- a/advanced_bank_reconciliation/public/js/journal_entry_reference_query.js
+++ b/advanced_bank_reconciliation/public/js/journal_entry_reference_query.js
@@ -7,8 +7,12 @@
 	}
 
 	const standard_set_custom_query = control_link.prototype.set_custom_query;
+	if (typeof standard_set_custom_query !== "function") {
+		return;
+	}
 
 	control_link.prototype.set_custom_query = function (args) {
+		args = args || {};
 		standard_set_custom_query.call(this, args);
 
 		const is_journal_entry_reference =


### PR DESCRIPTION
## Summary
- Add a Journal Entry doctype script from ABR.
- Remove the inherited docstatus filter only when Journal Entry Account reference_name points to Customer, Supplier, or Employee.
- Preserve ERPNext standard reference filtering for submitted transactional documents.

## Testing
- Ran git diff --check.
- Verified locally on demo.localhost that Supplier and Customer reference searches send empty filters and return matching records.
- Confirmed the final served doctype script includes the clean patch with no temporary tracing code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Journal Entry reference-field behavior improved so party-type references (Customer, Supplier, Employee) fall back to the correct default lookup.
  * Prevents custom query overrides from breaking or returning empty results when selecting reference_name on Journal Entry rows.
  * Reduces incorrect lookups by ensuring the standard lookup logic is used for affected reference fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/one-highflyer/advanced_bank_reconciliation/pull/85?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->