### PR TITLE
feat(bank-rec): filter bank accounts by company

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ The system automatically:
 
 ## Installation
 
+### Frontend Build Requirement
+
+The modern Bank Rec route app uses frontend packages that require Node.js 20.19.0 or newer.
+If your deployment builder defaults to Node 18, select a custom Node.js 20.19.0+ runtime before running `bench get-app`, `yarn install`, or `bench build`.
+
 ```bash
 # Get the app
 bench get-app https://github.com/one-highflyer/advanced_bank_reconciliation

--- a/advanced_bank_reconciliation/api/bank_rec.py
+++ b/advanced_bank_reconciliation/api/bank_rec.py
@@ -95,6 +95,24 @@ def _bank_account_to_dto(row):
 	}
 
 
+def _get_bank_account_companies():
+	allowed_companies = get_allowed_company_names()
+	if not allowed_companies:
+		return []
+
+	rows = frappe.get_list(
+		"Bank Account",
+		filters={
+			"is_company_account": 1,
+			"company": ["in", allowed_companies],
+		},
+		pluck="company",
+		group_by="company",
+		order_by="company asc",
+	)
+	return sorted({company for company in rows if company})
+
+
 def _get_filtered_transactions(bank_account, from_date=None, to_date=None, status="unreconciled"):
 	assert_bank_account_access(bank_account)
 
@@ -127,6 +145,7 @@ def get_boot():
 		"lang": frappe.local.lang,
 		"dir": "rtl" if is_rtl() else "ltr",
 		"allowed_roles": sorted(frappe.get_roles()),
+		"allowed_companies": _get_bank_account_companies(),
 		"settings": get_abr_default_settings(),
 		"accounting_dimensions": get_accounting_dimensions_for_dialog(),
 	}

--- a/advanced_bank_reconciliation/api/test_bank_rec.py
+++ b/advanced_bank_reconciliation/api/test_bank_rec.py
@@ -144,6 +144,7 @@ class TestBankRecPhaseOneAPI(FrappeTestCase):
 		self.assertEqual(boot["default_route"], "/bank-rec/reconcile")
 		self.assertIn("settings", boot)
 		self.assertIn("csrf_token", boot)
+		self.assertEqual(boot["allowed_companies"], [TEST_COMPANY])
 
 	def test_bank_accounts_are_limited_to_permitted_company(self):
 		with self.set_user(self.accounts_user):
@@ -152,6 +153,22 @@ class TestBankRecPhaseOneAPI(FrappeTestCase):
 		names = {row["name"] for row in accounts}
 		self.assertIn(self.bank_account_a, names)
 		self.assertNotIn(self.bank_account_b, names)
+
+	def test_bank_accounts_can_be_filtered_by_permitted_company(self):
+		with self.set_user(self.accounts_user):
+			accounts = get_bank_accounts(company=TEST_COMPANY)
+
+		names = {row["name"] for row in accounts}
+		self.assertIn(self.bank_account_a, names)
+		self.assertNotIn(self.bank_account_b, names)
+
+	def test_bank_account_filter_rejects_unpermitted_company(self):
+		with self.set_user(self.accounts_user):
+			self.assertRaises(
+				frappe.PermissionError,
+				get_bank_accounts,
+				company=TEST_COMPANY_2,
+			)
 
 	def test_cross_company_bank_account_is_rejected(self):
 		with self.set_user(self.accounts_user):

--- a/bank_rec/src/components/BankAccountFilters.vue
+++ b/bank_rec/src/components/BankAccountFilters.vue
@@ -4,6 +4,8 @@ import type { BankAccount, TransactionStatusFilter } from "@/types/bankRec";
 import RefreshCcw from "~icons/lucide/refresh-cw";
 
 const props = defineProps<{
+  companies: string[];
+  selectedCompany: string;
   bankAccounts: BankAccount[];
   selectedBankAccount: string;
   fromDate: string;
@@ -16,6 +18,7 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
+  "update:selectedCompany": [value: string];
   "update:selectedBankAccount": [value: string];
   "update:fromDate": [value: string];
   "update:toDate": [value: string];
@@ -24,8 +27,20 @@ const emit = defineEmits<{
   refresh: [];
 }>();
 
+const companyOptions = computed(() => [
+  { label: "Select company", value: "", disabled: true },
+  ...props.companies.map((company) => ({
+    label: company,
+    value: company,
+  })),
+]);
+
 const bankAccountOptions = computed(() => [
-  { label: "Select bank account", value: "", disabled: true },
+  {
+    label: props.selectedCompany ? "Select bank account" : "Select company first",
+    value: "",
+    disabled: true,
+  },
   ...props.bankAccounts.map((account) => ({
     label: account.account_name || account.name,
     value: account.name,
@@ -50,14 +65,26 @@ function updateStatementBalance(value: unknown) {
   <section class="rounded-lg border border-bank-line bg-white p-3 shadow-sm">
     <div class="flex flex-wrap items-end gap-3">
       <FormControl
-        class="min-w-[260px] flex-1"
+        class="min-w-[220px] flex-1"
+        type="select"
+        label="Company"
+        variant="outline"
+        size="md"
+        :options="companyOptions"
+        :model-value="selectedCompany"
+        :disabled="loading || !companies.length"
+        @update:model-value="emit('update:selectedCompany', String($event || ''))"
+      />
+
+      <FormControl
+        class="min-w-[260px] flex-[1.25]"
         type="select"
         label="Bank account"
         variant="outline"
         size="md"
         :options="bankAccountOptions"
         :model-value="selectedBankAccount"
-        :disabled="loading || !bankAccounts.length"
+        :disabled="loading || !selectedCompany || !bankAccounts.length"
         @update:model-value="emit('update:selectedBankAccount', String($event || ''))"
       />
 

--- a/bank_rec/src/env.d.ts
+++ b/bank_rec/src/env.d.ts
@@ -20,6 +20,7 @@ interface Window {
   lang?: string;
   dir?: "ltr" | "rtl";
   allowed_roles?: string[];
+  allowed_companies?: string[];
   settings?: Record<string, unknown>;
   accounting_dimensions?: Record<string, unknown>[];
 }

--- a/bank_rec/src/pages/CashCodingPage.vue
+++ b/bank_rec/src/pages/CashCodingPage.vue
@@ -91,6 +91,7 @@ async function replaceQuery() {
   await router.replace({
     path: route.path,
     query: {
+      company: store.selectedCompany || undefined,
       bank_account: store.selectedBankAccount || undefined,
       from_date: store.fromDate || undefined,
       to_date: store.toDate || undefined,
@@ -100,6 +101,10 @@ async function replaceQuery() {
 
 async function loadRows(options: { confirmDiscard?: boolean } = {}) {
   if (!store.selectedBankAccount) {
+    rows.value = [];
+    selected.value = [];
+    rowErrors.value = {};
+    await replaceQuery();
     return;
   }
 
@@ -143,13 +148,17 @@ async function loadRows(options: { confirmDiscard?: boolean } = {}) {
 }
 
 async function updateFilter(
-  field: "selectedBankAccount" | "fromDate" | "toDate",
+  field: "selectedCompany" | "selectedBankAccount" | "fromDate" | "toDate",
   value: string
 ) {
   if (!guardDiscard()) {
     return;
   }
-  store[field] = value;
+  if (field === "selectedCompany") {
+    await store.changeCompany(value);
+  } else {
+    store[field] = value;
+  }
   await loadRows({ confirmDiscard: false });
 }
 
@@ -261,11 +270,14 @@ onBeforeRouteLeave(() => guardDiscard());
 <template>
   <div class="flex min-h-0 w-full flex-1 flex-col gap-4 lg:h-[calc(100vh-103px)] lg:overflow-hidden">
     <BankAccountFilters
+      :companies="store.allowedCompanies"
+      :selected-company="store.selectedCompany"
       :bank-accounts="store.bankAccounts"
       :selected-bank-account="store.selectedBankAccount"
       :from-date="store.fromDate"
       :to-date="store.toDate"
       :loading="loading || submitting"
+      @update:selected-company="updateFilter('selectedCompany', $event)"
       @update:selected-bank-account="updateFilter('selectedBankAccount', $event)"
       @update:from-date="updateFilter('fromDate', $event)"
       @update:to-date="updateFilter('toDate', $event)"

--- a/bank_rec/src/pages/CashCodingPage.vue
+++ b/bank_rec/src/pages/CashCodingPage.vue
@@ -104,6 +104,7 @@ async function loadRows(options: { confirmDiscard?: boolean } = {}) {
     rows.value = [];
     selected.value = [];
     rowErrors.value = {};
+    clearDirty();
     await replaceQuery();
     return;
   }

--- a/bank_rec/src/pages/MatchedPage.vue
+++ b/bank_rec/src/pages/MatchedPage.vue
@@ -80,6 +80,7 @@ async function replaceQuery() {
   await router.replace({
     path: route.path,
     query: {
+      company: store.selectedCompany || undefined,
       bank_account: store.selectedBankAccount || undefined,
       from_date: store.fromDate || undefined,
       to_date: store.toDate || undefined,
@@ -90,6 +91,9 @@ async function replaceQuery() {
 
 async function loadRows() {
   if (!store.selectedBankAccount) {
+    rows.value = [];
+    selectedName.value = "";
+    await replaceQuery();
     return;
   }
 
@@ -131,10 +135,14 @@ async function loadRows() {
 }
 
 async function updateFilter(
-  field: "selectedBankAccount" | "fromDate" | "toDate",
+  field: "selectedCompany" | "selectedBankAccount" | "fromDate" | "toDate",
   value: string
 ) {
-  store[field] = value;
+  if (field === "selectedCompany") {
+    await store.changeCompany(value);
+  } else {
+    store[field] = value;
+  }
   selectedName.value = "";
   await loadRows();
 }
@@ -187,11 +195,14 @@ onMounted(async () => {
 <template>
   <div class="flex min-h-0 w-full flex-1 flex-col gap-4 lg:h-[calc(100vh-103px)] lg:overflow-hidden">
     <BankAccountFilters
+      :companies="store.allowedCompanies"
+      :selected-company="store.selectedCompany"
       :bank-accounts="store.bankAccounts"
       :selected-bank-account="store.selectedBankAccount"
       :from-date="store.fromDate"
       :to-date="store.toDate"
       :loading="loading || Boolean(submittingName)"
+      @update:selected-company="updateFilter('selectedCompany', $event)"
       @update:selected-bank-account="updateFilter('selectedBankAccount', $event)"
       @update:from-date="updateFilter('fromDate', $event)"
       @update:to-date="updateFilter('toDate', $event)"

--- a/bank_rec/src/pages/ReconcilePage.vue
+++ b/bank_rec/src/pages/ReconcilePage.vue
@@ -80,10 +80,17 @@ async function selectTransaction(name: string) {
 }
 
 async function updateFilter(
-  field: "selectedBankAccount" | "fromDate" | "toDate" | "transactionStatus",
+  field:
+    | "selectedCompany"
+    | "selectedBankAccount"
+    | "fromDate"
+    | "toDate"
+    | "transactionStatus",
   value: string
 ) {
-  if (field === "transactionStatus") {
+  if (field === "selectedCompany") {
+    await store.changeCompany(value);
+  } else if (field === "transactionStatus") {
     store.transactionStatus = value as TransactionStatusFilter;
   } else {
     store[field] = value;
@@ -180,6 +187,8 @@ watch(
 
     <template v-else>
       <BankAccountFilters
+        :companies="store.allowedCompanies"
+        :selected-company="store.selectedCompany"
         :bank-accounts="store.bankAccounts"
         :selected-bank-account="store.selectedBankAccount"
         :from-date="store.fromDate"
@@ -189,6 +198,7 @@ watch(
         show-statement-balance
         show-status
         :loading="pageLoading || store.loading.transactions || store.loading.summary"
+        @update:selected-company="updateFilter('selectedCompany', $event)"
         @update:selected-bank-account="updateFilter('selectedBankAccount', $event)"
         @update:from-date="updateFilter('fromDate', $event)"
         @update:to-date="updateFilter('toDate', $event)"

--- a/bank_rec/src/pages/RulesPage.vue
+++ b/bank_rec/src/pages/RulesPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from "vue";
+import { computed, onMounted, ref } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import BankAccountFilters from "@/components/BankAccountFilters.vue";
 import EmptyState from "@/components/EmptyState.vue";
@@ -40,6 +40,7 @@ async function replaceQuery() {
   await router.replace({
     path: route.path,
     query: {
+      company: store.selectedCompany || undefined,
       bank_account: selectedBankAccount.value || undefined,
     },
   });
@@ -50,24 +51,36 @@ async function loadRules() {
   await replaceQuery();
 }
 
+async function updateCompany(company: string) {
+  await store.changeCompany(company);
+  selectedBankAccount.value = store.selectedBankAccount;
+  await loadRules();
+}
+
+async function updateBankAccount(bankAccount: string) {
+  selectedBankAccount.value = bankAccount;
+  await loadRules();
+}
+
 onMounted(async () => {
   await store.initialize(route.query);
   selectedBankAccount.value = store.selectedBankAccount;
   await loadRules();
 });
-
-watch(selectedBankAccount, loadRules);
 </script>
 
 <template>
   <div class="flex min-h-0 w-full flex-col gap-4">
     <BankAccountFilters
+      :companies="store.allowedCompanies"
+      :selected-company="store.selectedCompany"
       :bank-accounts="store.bankAccounts"
       :selected-bank-account="selectedBankAccount"
       :from-date="store.fromDate"
       :to-date="store.toDate"
       :loading="store.loading.bankAccounts || store.loading.rules"
-      @update:selected-bank-account="selectedBankAccount = $event"
+      @update:selected-company="updateCompany"
+      @update:selected-bank-account="updateBankAccount"
       @update:from-date="store.fromDate = $event"
       @update:to-date="store.toDate = $event"
       @refresh="loadRules"

--- a/bank_rec/src/stores/bankRec.ts
+++ b/bank_rec/src/stores/bankRec.ts
@@ -161,7 +161,13 @@ export const useBankRecStore = defineStore("bankRec", {
 
   actions: {
     applyQuery(query: LocationQuery) {
-      this.selectedCompany = stringQuery(query.company, this.selectedCompany);
+      const queryCompany = stringQuery(query.company);
+      const queryBankAccount = stringQuery(query.bank_account);
+      if (queryCompany) {
+        this.selectedCompany = queryCompany;
+      } else if (queryBankAccount) {
+        this.selectedCompany = "";
+      }
       this.selectedBankAccount = stringQuery(
         query.bank_account,
         this.selectedBankAccount
@@ -250,6 +256,16 @@ export const useBankRecStore = defineStore("bankRec", {
         if (selectedAccount && !this.selectedCompany) {
           this.selectedCompany = selectedAccount.company;
           this.bankAccounts = await getBankAccounts(this.selectedCompany);
+        }
+
+        if (resolveCompanyFromAccount && !selectedAccount) {
+          this.selectedBankAccount = "";
+          this.selectedTransactionName = "";
+          this.selectedContext = null;
+          this.ensureSelectedCompany();
+          this.bankAccounts = this.selectedCompany
+            ? await getBankAccounts(this.selectedCompany)
+            : [];
         }
 
         if (

--- a/bank_rec/src/stores/bankRec.ts
+++ b/bank_rec/src/stores/bankRec.ts
@@ -79,6 +79,7 @@ function windowBoot(): BootData | null {
     lang: window.lang || "en",
     dir: window.dir || "ltr",
     allowed_roles: window.allowed_roles || [],
+    allowed_companies: window.allowed_companies || [],
     settings: window.settings || {},
     accounting_dimensions: window.accounting_dimensions || [],
   };
@@ -87,6 +88,7 @@ function windowBoot(): BootData | null {
 export const useBankRecStore = defineStore("bankRec", {
   state: () => ({
     boot: null as BootData | null,
+    selectedCompany: "",
     bankAccounts: [] as BankAccount[],
     selectedBankAccount: "",
     fromDate: monthStartIso(),
@@ -139,6 +141,9 @@ export const useBankRecStore = defineStore("bankRec", {
   }),
 
   getters: {
+    allowedCompanies(state): string[] {
+      return state.boot?.allowed_companies || [];
+    },
     selectedBankAccountDoc(state): BankAccount | undefined {
       return state.bankAccounts.find(
         (account) => account.name === state.selectedBankAccount
@@ -156,6 +161,7 @@ export const useBankRecStore = defineStore("bankRec", {
 
   actions: {
     applyQuery(query: LocationQuery) {
+      this.selectedCompany = stringQuery(query.company, this.selectedCompany);
       this.selectedBankAccount = stringQuery(
         query.bank_account,
         this.selectedBankAccount
@@ -178,6 +184,7 @@ export const useBankRecStore = defineStore("bankRec", {
 
     queryState() {
       return {
+        company: this.selectedCompany || undefined,
         bank_account: this.selectedBankAccount || undefined,
         from_date: this.fromDate || undefined,
         to_date: this.toDate || undefined,
@@ -209,12 +216,42 @@ export const useBankRecStore = defineStore("bankRec", {
       }
     },
 
+    ensureSelectedCompany() {
+      const allowedCompanies = this.allowedCompanies;
+      if (
+        this.selectedCompany &&
+        allowedCompanies.includes(this.selectedCompany)
+      ) {
+        return;
+      }
+
+      this.selectedCompany = allowedCompanies[0] || "";
+    },
+
     async loadBankAccounts() {
       this.loading.bankAccounts = true;
       this.errors.bankAccounts = "";
 
       try {
-        this.bankAccounts = await getBankAccounts();
+        const resolveCompanyFromAccount =
+          Boolean(this.selectedBankAccount) && !this.selectedCompany;
+
+        if (!resolveCompanyFromAccount) {
+          this.ensureSelectedCompany();
+        }
+
+        this.bankAccounts = await getBankAccounts(
+          resolveCompanyFromAccount ? undefined : this.selectedCompany
+        );
+
+        const selectedAccount = this.bankAccounts.find(
+          (account) => account.name === this.selectedBankAccount
+        );
+        if (selectedAccount && !this.selectedCompany) {
+          this.selectedCompany = selectedAccount.company;
+          this.bankAccounts = await getBankAccounts(this.selectedCompany);
+        }
+
         if (
           this.selectedBankAccount &&
           !this.bankAccounts.some(
@@ -223,6 +260,7 @@ export const useBankRecStore = defineStore("bankRec", {
         ) {
           this.selectedBankAccount = "";
           this.selectedTransactionName = "";
+          this.selectedContext = null;
         }
         if (!this.selectedBankAccount && this.bankAccounts.length) {
           this.selectedBankAccount = this.bankAccounts[0].name;
@@ -235,6 +273,23 @@ export const useBankRecStore = defineStore("bankRec", {
       } finally {
         this.loading.bankAccounts = false;
       }
+    },
+
+    async changeCompany(company: string) {
+      if (this.selectedCompany === company) {
+        return;
+      }
+
+      this.selectedCompany = company;
+      this.bankAccounts = [];
+      this.selectedBankAccount = "";
+      this.selectedTransactionName = "";
+      this.selectedContext = null;
+      this.transactions = [];
+      this.summary = null;
+      this.matchCandidates = [];
+      this.createDefaults = null;
+      await this.loadBankAccounts();
     },
 
     async loadTransactions() {

--- a/bank_rec/src/types/bankRec.ts
+++ b/bank_rec/src/types/bankRec.ts
@@ -6,6 +6,7 @@ export interface BootData {
   lang: string;
   dir: "ltr" | "rtl";
   allowed_roles: string[];
+  allowed_companies: string[];
   settings: Record<string, unknown>;
   accounting_dimensions: Record<string, unknown>[];
 }


### PR DESCRIPTION
## Summary
- add Company as the first filter in the Bank Rec route app
- filter bank accounts by the selected permitted company across Reconcile, Cash Coding, Matched, and Rules
- document the Node.js 20.19.0+ build requirement for the route app

## Validation
- yarn install --frozen-lockfile
- yarn build
- bench --site <local-site> run-tests --app advanced_bank_reconciliation --module advanced_bank_reconciliation.api.test_bank_rec
- bench build --app advanced_bank_reconciliation
- Chrome browser validation on a local site for Reconcile, Cash Coding, Matched, Rules, company switching, and bank-account-only links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Company filtering: Added a company selector to bank account filtering, scoping available bank accounts and reconciliation views to the chosen company.

* **Bug Fixes**
  * Improved filter behavior: Company and bank account selections now stay consistent across page loads and URL query updates, including clearing dependent selections when switching/clearing.

* **Documentation**
  * Build requirements: Documented that Node.js 20.19.0+ is required for the modern Bank Rec route app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->