### PR TITLE
fix(bank-rec): show dimensions and search match candidates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   FRAPPE_BRANCH: version-15
+  CI: "Yes"
 
 concurrency:
   group: ci-${{ github.ref }}-${{ github.event.number || github.sha }}
@@ -98,18 +99,40 @@ jobs:
           mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "SET GLOBAL character_set_server = 'utf8mb4'"
           mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "SET GLOBAL collation_server = 'utf8mb4_unicode_ci'"
 
-      - name: Install
+      - name: Get ERPNext
         working-directory: ${{ github.workspace }}/../frappe-bench
         run: |
           bench get-app erpnext --branch "$FRAPPE_BRANCH"
+
+      - name: Get app
+        working-directory: ${{ github.workspace }}/../frappe-bench
+        run: |
           bench get-app advanced_bank_reconciliation $GITHUB_WORKSPACE
+
+      - name: Setup requirements
+        working-directory: ${{ github.workspace }}/../frappe-bench
+        run: |
           bench setup requirements --dev
+
+      - name: Create test site
+        working-directory: ${{ github.workspace }}/../frappe-bench
+        run: |
           bench new-site --db-root-password root --admin-password admin test_site
+
+      - name: Install ERPNext
+        working-directory: ${{ github.workspace }}/../frappe-bench
+        run: |
           bench --site test_site install-app erpnext
+
+      - name: Install app
+        working-directory: ${{ github.workspace }}/../frappe-bench
+        run: |
           bench --site test_site install-app advanced_bank_reconciliation
-          bench build
-        env:
-          CI: "Yes"
+
+      - name: Build app assets
+        working-directory: ${{ github.workspace }}/../frappe-bench
+        run: |
+          bench build --app advanced_bank_reconciliation
 
       - name: Run Tests
         working-directory: ${{ github.workspace }}/../frappe-bench

--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/advance_bank_reconciliation_tool.js
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/advance_bank_reconciliation_tool.js
@@ -28,7 +28,7 @@ function render_modern_bank_rec_prompt(frm) {
 			<div class="abr-modern-bank-rec-prompt alert alert-info" style="display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 12px; margin-bottom: 16px;">
 				<div>
 					<div><strong>${__("Try the new Bank Rec")}</strong></div>
-					<div class="small text-muted">${__("Use the split-screen reconciliation and cash coding views with the current filters.")}</div>
+					<div class="small text-muted">${__("Use the split-screen reconciliation and bank coding views with the current filters.")}</div>
 				</div>
 				<a class="btn btn-sm btn-primary" href="/bank-rec/reconcile">${__("Open Bank Rec")}</a>
 			</div>

--- a/advanced_bank_reconciliation/api/accounting_dimensions.py
+++ b/advanced_bank_reconciliation/api/accounting_dimensions.py
@@ -1,0 +1,101 @@
+import frappe
+
+from advanced_bank_reconciliation.utils.logger import get_logger
+
+
+def _get_dimension_checks(company):
+	try:
+		from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
+			get_checks_for_pl_and_bs_accounts,
+		)
+	except ImportError:
+		return {}
+
+	checks = {}
+	for row in get_checks_for_pl_and_bs_accounts():
+		if company and row.company != company:
+			continue
+		checks[row.fieldname] = {
+			"default_value": row.default_dimension or "",
+			"mandatory_for_bs": bool(row.mandatory_for_bs),
+			"mandatory_for_pl": bool(row.mandatory_for_pl),
+		}
+	return checks
+
+
+def get_accounting_dimension_fields(company=None):
+	"""Return custom accounting dimension field metadata for the bank rec UI."""
+	try:
+		from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
+			get_accounting_dimensions,
+		)
+
+		dimensions = get_accounting_dimensions(as_list=False)
+	except ImportError:
+		return []
+	except Exception:
+		get_logger().warning("Failed to fetch accounting dimensions", exc_info=True)
+		return []
+
+	checks = _get_dimension_checks(company)
+	result = []
+	for dim in dimensions:
+		try:
+			has_company_field = bool(frappe.get_meta(dim.document_type).has_field("company"))
+		except Exception:
+			has_company_field = False
+		result.append(
+			{
+				"fieldname": dim.fieldname,
+				"fieldtype": "Link",
+				"label": dim.label,
+				"options": dim.document_type,
+				"has_company_field": has_company_field,
+				"default_value": checks.get(dim.fieldname, {}).get("default_value", ""),
+				"mandatory_for_bs": checks.get(dim.fieldname, {}).get("mandatory_for_bs", False),
+				"mandatory_for_pl": checks.get(dim.fieldname, {}).get("mandatory_for_pl", False),
+			}
+		)
+	return result
+
+
+def get_accounting_dimension_options(dimensions, company=None):
+	options = {}
+
+	for dimension in dimensions:
+		fieldname = dimension.get("fieldname")
+		doctype = dimension.get("options")
+		if not fieldname or not doctype:
+			continue
+
+		filters = {}
+		if dimension.get("has_company_field") and company:
+			filters["company"] = company
+
+		try:
+			meta = frappe.get_meta(doctype)
+			fields = ["name"]
+			if meta.title_field and meta.title_field != "name":
+				fields.append(meta.title_field)
+			options[fieldname] = frappe.get_list(
+				doctype,
+				filters=filters,
+				fields=fields,
+				order_by="modified desc",
+				limit_page_length=100,
+			)
+		except Exception:
+			get_logger().warning(
+				"Failed to fetch accounting dimension options for %s", fieldname, exc_info=True
+			)
+			options[fieldname] = []
+
+	return options
+
+
+def get_accounting_dimension_context(company=None):
+	dimensions = get_accounting_dimension_fields(company)
+	return {
+		"accounting_dimensions": dimensions,
+		"dimension_options": get_accounting_dimension_options(dimensions, company),
+	}

--- a/advanced_bank_reconciliation/api/accounting_dimensions.py
+++ b/advanced_bank_reconciliation/api/accounting_dimensions.py
@@ -82,7 +82,7 @@ def get_accounting_dimension_options(dimensions, company=None):
 				filters=filters,
 				fields=fields,
 				order_by="modified desc",
-				limit_page_length=100,
+				limit_page_length=0,
 			)
 		except Exception:
 			get_logger().warning(

--- a/advanced_bank_reconciliation/api/bank_rec.py
+++ b/advanced_bank_reconciliation/api/bank_rec.py
@@ -84,14 +84,25 @@ def _dedupe_reconciled_rows(rows):
 
 
 def _bank_account_to_dto(row):
-	account_currency = frappe.get_cached_value("Account", row.account, "account_currency")
+	account = (
+		frappe.get_cached_value(
+			"Account",
+			row.account,
+			["account_currency", "root_type", "report_type"],
+			as_dict=True,
+		)
+		if row.account
+		else {}
+	) or {}
 	return {
 		"name": row.name,
 		"account_name": row.account_name,
 		"bank": row.bank,
 		"account": row.account,
 		"company": row.company,
-		"currency": account_currency,
+		"currency": account.get("account_currency"),
+		"account_root_type": account.get("root_type"),
+		"account_report_type": account.get("report_type"),
 	}
 
 

--- a/advanced_bank_reconciliation/api/cash_coding.py
+++ b/advanced_bank_reconciliation/api/cash_coding.py
@@ -6,6 +6,7 @@ from advanced_bank_reconciliation.advanced_bank_reconciliation.doctype.advance_b
 	create_journal_entry_bts,
 	get_abr_default_settings,
 )
+from advanced_bank_reconciliation.api.accounting_dimensions import get_accounting_dimension_context
 from advanced_bank_reconciliation.api.bank_rec import _transaction_to_dto, get_transactions
 from advanced_bank_reconciliation.api.matching import _lock_bank_transaction
 from advanced_bank_reconciliation.api.permission import (
@@ -89,6 +90,7 @@ def _row_success(row, transaction):
 def get_cash_coding_rows(bank_account, from_date=None, to_date=None):
 	bank_account_doc = assert_bank_account_access(bank_account)
 	company = bank_account_doc.company
+	dimension_context = get_accounting_dimension_context(company)
 	rows = get_transactions(
 		bank_account=bank_account,
 		from_date=from_date,
@@ -104,6 +106,7 @@ def get_cash_coding_rows(bank_account, from_date=None, to_date=None):
 				"party": row.get("party") or "",
 				"cost_center": "",
 				"project": "",
+				"dimensions": {},
 				"reference_number": row.get("reference_number") or "",
 				"notes": "",
 				"suggested_rule": None,
@@ -132,6 +135,7 @@ def get_cash_coding_rows(bank_account, from_date=None, to_date=None):
 				order_by="modified desc",
 				limit_page_length=100,
 			),
+			**dimension_context,
 		},
 	}
 

--- a/advanced_bank_reconciliation/api/cash_coding.py
+++ b/advanced_bank_reconciliation/api/cash_coding.py
@@ -68,7 +68,7 @@ def _row_success(row, transaction):
 		or abs(flt(transaction.unallocated_amount)) > 0.01
 		or not transaction.get("payment_entries")
 	):
-		frappe.throw(_("Cash coding did not reconcile the bank transaction."))
+		frappe.throw(_("Bank coding did not reconcile the bank transaction."))
 
 	voucher = None
 	for payment in transaction.get("payment_entries", []):
@@ -172,7 +172,7 @@ def preview_cash_coding(rows):
 				}
 			)
 		except Exception as exc:
-			results.append(_row_exception_error(row, exc, "Bank Rec cash coding preview failed"))
+			results.append(_row_exception_error(row, exc, "Bank Rec bank coding preview failed"))
 
 	return {"results": results}
 
@@ -231,7 +231,7 @@ def submit_cash_coding(rows):
 			frappe.db.release_savepoint(savepoint)
 		except Exception as exc:
 			frappe.db.rollback(save_point=savepoint)
-			results.append(_row_exception_error(row, exc, "Bank Rec cash coding submit failed"))
+			results.append(_row_exception_error(row, exc, "Bank Rec bank coding submit failed"))
 
 	return {
 		"results": results,

--- a/advanced_bank_reconciliation/api/create_voucher.py
+++ b/advanced_bank_reconciliation/api/create_voucher.py
@@ -12,6 +12,7 @@ from advanced_bank_reconciliation.advanced_bank_reconciliation.doctype.advance_b
 	create_payment_entry_bts,
 	get_abr_default_settings,
 )
+from advanced_bank_reconciliation.api.accounting_dimensions import get_accounting_dimension_context
 from advanced_bank_reconciliation.api.bank_rec import _bank_account_to_dto, _transaction_to_dto
 from advanced_bank_reconciliation.api.matching import _linked_payment_dto, _lock_bank_transaction
 from advanced_bank_reconciliation.api.permission import (
@@ -186,6 +187,7 @@ def get_create_defaults(bank_transaction_name):
 	company = _get_company(transaction)
 	bank_account = frappe.get_doc("Bank Account", transaction.bank_account)
 	settings = get_abr_default_settings()
+	dimension_context = get_accounting_dimension_context(company)
 
 	accounts = frappe.get_list(
 		"Account",
@@ -231,6 +233,7 @@ def get_create_defaults(bank_transaction_name):
 			"mode_of_payments": mode_of_payments,
 			"cost_centers": cost_centers,
 			"projects": projects,
+			**dimension_context,
 		},
 	}
 

--- a/advanced_bank_reconciliation/api/test_bank_rec.py
+++ b/advanced_bank_reconciliation/api/test_bank_rec.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import frappe
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils import add_days, flt, nowdate
@@ -595,6 +597,43 @@ class TestBankRecPhaseThreeAPI(FrappeTestCase):
 		self.assertTrue(result["options"]["accounts"])
 		self.assertIn("posting_date", result["defaults"])
 
+	def test_create_defaults_include_accounting_dimensions(self):
+		bank_transaction = create_test_bank_transaction(
+			self.bank_account,
+			withdrawal=27,
+			reference_number="_ABR-PHASE3-DIMS",
+		)
+		dimension_context = {
+			"accounting_dimensions": [
+				{
+					"fieldname": "region",
+					"fieldtype": "Link",
+					"label": "Region",
+					"options": "Region",
+					"has_company_field": True,
+					"default_value": "_Test Region",
+					"mandatory_for_bs": True,
+					"mandatory_for_pl": False,
+				}
+			],
+			"dimension_options": {"region": [{"name": "_Test Region"}]},
+		}
+
+		with patch(
+			"advanced_bank_reconciliation.api.create_voucher.get_accounting_dimension_context",
+			return_value=dimension_context,
+		):
+			result = get_create_defaults(bank_transaction.name)
+
+		self.assertEqual(
+			result["options"]["accounting_dimensions"],
+			dimension_context["accounting_dimensions"],
+		)
+		self.assertEqual(
+			result["options"]["dimension_options"],
+			dimension_context["dimension_options"],
+		)
+
 	def test_create_journal_entry_from_withdrawal_reconciles_transaction(self):
 		bank_transaction = create_test_bank_transaction(
 			self.bank_account,
@@ -794,6 +833,51 @@ class TestBankRecPhaseFourAPI(FrappeTestCase):
 
 		names = {row["transaction"]["name"] for row in result["rows"]}
 		self.assertIn(bank_transaction.name, names)
+
+	def test_cash_coding_rows_include_accounting_dimensions(self):
+		bank_transaction = create_test_bank_transaction(
+			self.bank_account,
+			withdrawal=17,
+			reference_number="_ABR-PHASE4-DIMS",
+		)
+		dimension_context = {
+			"accounting_dimensions": [
+				{
+					"fieldname": "region",
+					"fieldtype": "Link",
+					"label": "Region",
+					"options": "Region",
+					"has_company_field": True,
+					"default_value": "_Test Region",
+					"mandatory_for_bs": True,
+					"mandatory_for_pl": False,
+				}
+			],
+			"dimension_options": {"region": [{"name": "_Test Region"}]},
+		}
+
+		with patch(
+			"advanced_bank_reconciliation.api.cash_coding.get_accounting_dimension_context",
+			return_value=dimension_context,
+		):
+			result = get_cash_coding_rows(
+				self.bank_account,
+				from_date=add_days(nowdate(), -1),
+				to_date=add_days(nowdate(), 1),
+			)
+
+		row = next(
+			row for row in result["rows"] if row["transaction"]["name"] == bank_transaction.name
+		)
+		self.assertEqual(row["dimensions"], {})
+		self.assertEqual(
+			result["options"]["accounting_dimensions"],
+			dimension_context["accounting_dimensions"],
+		)
+		self.assertEqual(
+			result["options"]["dimension_options"],
+			dimension_context["dimension_options"],
+		)
 
 	def test_submit_cash_coding_reconciles_valid_row(self):
 		bank_transaction = create_test_bank_transaction(

--- a/bank_rec/src/components/AppShell.vue
+++ b/bank_rec/src/components/AppShell.vue
@@ -20,8 +20,8 @@ const navItems = [
     icon: CheckCircle2,
   },
   {
-    label: "Cash Coding",
-    to: "/cash-coding",
+    label: "Bank Coding",
+    to: "/bank-coding",
     icon: Table2,
   },
   {

--- a/bank_rec/src/components/CreateVoucherPanel.vue
+++ b/bank_rec/src/components/CreateVoucherPanel.vue
@@ -61,6 +61,26 @@ const accountingDimensions = computed(
 const dimensionOptions = computed(
   () => props.defaults?.options.dimension_options || {}
 );
+function isBalanceSheetRootType(rootType?: string) {
+  return ["Asset", "Liability", "Equity"].includes(rootType || "");
+}
+
+const bankAccountIsBalanceSheet = computed(() => {
+  const bankAccount = props.defaults?.bank_account;
+  if (!bankAccount?.account) {
+    return false;
+  }
+  if (!bankAccount.account_report_type && !bankAccount.account_root_type) {
+    return true;
+  }
+  return (
+    bankAccount.account_report_type === "Balance Sheet" ||
+    isBalanceSheetRootType(bankAccount.account_root_type)
+  );
+});
+const selectedAccountIsBalanceSheet = computed(() =>
+  isBalanceSheetRootType(accountOption.value?.root_type)
+);
 const selectedAccountIsProfitAndLoss = computed(() =>
   ["Income", "Expense"].includes(accountOption.value?.root_type || "")
 );
@@ -121,8 +141,9 @@ function dimensionOptionLabel(option: DimensionOption) {
 
 function isDimensionRequired(dimension: AccountingDimension) {
   return Boolean(
-    dimension.mandatory_for_bs ||
-      (selectedAccountIsProfitAndLoss.value && dimension.mandatory_for_pl)
+    (dimension.mandatory_for_bs &&
+      (bankAccountIsBalanceSheet.value || selectedAccountIsBalanceSheet.value)) ||
+      (dimension.mandatory_for_pl && selectedAccountIsProfitAndLoss.value)
   );
 }
 

--- a/bank_rec/src/components/CreateVoucherPanel.vue
+++ b/bank_rec/src/components/CreateVoucherPanel.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
 import type {
+  AccountingDimension,
   BankTransaction,
   CreateDefaultsResponse,
   CreateVoucherPayload,
+  DimensionOption,
 } from "@/types/bankRec";
 import EmptyState from "@/components/EmptyState.vue";
 import ErrorState from "@/components/ErrorState.vue";
@@ -38,6 +40,7 @@ const referenceDate = ref("");
 const referenceNumber = ref("");
 const costCenter = ref("");
 const project = ref("");
+const dimensionValues = ref<Record<string, string>>({});
 const saveAsRule = ref(false);
 const ruleTitle = ref("");
 const validationError = ref("");
@@ -52,6 +55,15 @@ const partyTypeOptions = [
 const accountOption = computed(() =>
   props.defaults?.options.accounts.find((row) => row.name === account.value)
 );
+const accountingDimensions = computed(
+  () => props.defaults?.options.accounting_dimensions || []
+);
+const dimensionOptions = computed(
+  () => props.defaults?.options.dimension_options || {}
+);
+const selectedAccountIsProfitAndLoss = computed(() =>
+  ["Income", "Expense"].includes(accountOption.value?.root_type || "")
+);
 
 const isPaymentEntryPath = computed(() => !account.value && partyType.value && party.value);
 const contactLabel = computed(() =>
@@ -62,6 +74,7 @@ const accountLabel = computed(() =>
 );
 
 function payload(): CreateVoucherPayload {
+  const dimensions = getDimensionPayload();
   return {
     account: account.value,
     party_type: partyType.value,
@@ -72,9 +85,45 @@ function payload(): CreateVoucherPayload {
     reference_number: referenceNumber.value,
     cost_center: costCenter.value,
     project: project.value,
+    dimensions,
     save_as_rule: saveAsRule.value,
     rule_title: ruleTitle.value,
   };
+}
+
+function getDimensionPayload() {
+  const dimensions = Object.fromEntries(
+    Object.entries(dimensionValues.value).filter(([, value]) => Boolean(value))
+  );
+  return Object.keys(dimensions).length ? dimensions : undefined;
+}
+
+function defaultDimensionValues(dimensions: AccountingDimension[]) {
+  return Object.fromEntries(
+    dimensions.map((dimension) => [dimension.fieldname, dimension.default_value || ""])
+  );
+}
+
+function dimensionLabel(dimension: AccountingDimension) {
+  return dimension.label || dimension.fieldname;
+}
+
+function dimensionDatalistId(dimension: AccountingDimension) {
+  return `bank-rec-create-dimension-${dimension.fieldname}`;
+}
+
+function dimensionOptionLabel(option: DimensionOption) {
+  const displayValue = Object.entries(option).find(
+    ([key, value]) => key !== "name" && typeof value === "string" && value
+  )?.[1];
+  return typeof displayValue === "string" ? displayValue : option.name;
+}
+
+function isDimensionRequired(dimension: AccountingDimension) {
+  return Boolean(
+    dimension.mandatory_for_bs ||
+      (selectedAccountIsProfitAndLoss.value && dimension.mandatory_for_pl)
+  );
 }
 
 function validate() {
@@ -93,6 +142,13 @@ function validate() {
   }
   if (saveAsRule.value && !ruleTitle.value) {
     validationError.value = "Rule title is required when saving a rule.";
+    return false;
+  }
+  const missingDimension = accountingDimensions.value.find(
+    (dimension) => isDimensionRequired(dimension) && !dimensionValues.value[dimension.fieldname]
+  );
+  if (missingDimension) {
+    validationError.value = `${dimensionLabel(missingDimension)} is required.`;
     return false;
   }
   return true;
@@ -122,6 +178,9 @@ watch(
     referenceNumber.value = props.defaults?.defaults.reference_number || "";
     costCenter.value = "";
     project.value = "";
+    dimensionValues.value = defaultDimensionValues(
+      props.defaults?.options.accounting_dimensions || []
+    );
     saveAsRule.value = false;
     ruleTitle.value = "";
     validationError.value = "";
@@ -270,6 +329,25 @@ watch(
               :value="row.name"
             >
               {{ row.project_name || row.name }}
+            </option>
+          </datalist>
+        </div>
+
+        <div v-for="dimension in accountingDimensions" :key="dimension.fieldname">
+          <FormControl
+            v-model="dimensionValues[dimension.fieldname]"
+            :label="`${dimensionLabel(dimension)}${isDimensionRequired(dimension) ? ' *' : ''}`"
+            variant="outline"
+            size="md"
+            :list="dimensionDatalistId(dimension)"
+          />
+          <datalist :id="dimensionDatalistId(dimension)">
+            <option
+              v-for="option in dimensionOptions[dimension.fieldname] || []"
+              :key="option.name"
+              :value="option.name"
+            >
+              {{ dimensionOptionLabel(option) }}
             </option>
           </datalist>
         </div>

--- a/bank_rec/src/components/MatchPanel.vue
+++ b/bank_rec/src/components/MatchPanel.vue
@@ -35,9 +35,6 @@ const selectedKeys = ref<string[]>([]);
 const amounts = ref<Record<string, number | string | null>>({});
 const search = ref("");
 
-const selectedCandidates = computed(() =>
-  props.candidates.filter((candidate) => selectedKeys.value.includes(candidate.key))
-);
 const filteredCandidates = computed(() => {
   const term = search.value.trim().toLowerCase();
   if (!term) {
@@ -47,6 +44,9 @@ const filteredCandidates = computed(() => {
     candidateSearchText(candidate).includes(term)
   );
 });
+const selectedCandidates = computed(() =>
+  filteredCandidates.value.filter((candidate) => selectedKeys.value.includes(candidate.key))
+);
 
 function allocationAmount(candidate: MatchCandidate) {
   const value = amounts.value[candidate.key] ?? Math.abs(candidate.amount);
@@ -117,7 +117,10 @@ function candidateSearchText(candidate: MatchCandidate) {
     candidate.party_type,
     candidate.posting_date,
     candidate.reference_date,
+    formatDate(candidate.posting_date),
+    formatDate(candidate.reference_date),
     candidate.amount,
+    formatMoney(candidate.amount, candidate.currency || props.currency),
     candidate.currency,
     confidenceLabel(candidate.confidence),
     ...candidate.reasons,
@@ -214,6 +217,7 @@ watch(
             v-model="search"
             class="h-9 w-full rounded-md border border-bank-line bg-white pl-9 pr-3 text-sm outline-none focus:border-bank-accent focus:ring-2 focus:ring-blue-100"
             type="search"
+            aria-label="Search match candidates"
             placeholder="Search documents, references, parties, dates, amounts"
           />
         </div>

--- a/bank_rec/src/components/MatchPanel.vue
+++ b/bank_rec/src/components/MatchPanel.vue
@@ -14,6 +14,7 @@ import Check from "~icons/lucide/check";
 import CheckCircle2 from "~icons/lucide/check-circle-2";
 import ExternalLink from "~icons/lucide/external-link";
 import RefreshCcw from "~icons/lucide/refresh-cw";
+import Search from "~icons/lucide/search";
 
 const props = defineProps<{
   transaction?: BankTransaction;
@@ -32,10 +33,20 @@ const emit = defineEmits<{
 
 const selectedKeys = ref<string[]>([]);
 const amounts = ref<Record<string, number | string | null>>({});
+const search = ref("");
 
 const selectedCandidates = computed(() =>
   props.candidates.filter((candidate) => selectedKeys.value.includes(candidate.key))
 );
+const filteredCandidates = computed(() => {
+  const term = search.value.trim().toLowerCase();
+  if (!term) {
+    return props.candidates;
+  }
+  return props.candidates.filter((candidate) =>
+    candidateSearchText(candidate).includes(term)
+  );
+});
 
 function allocationAmount(candidate: MatchCandidate) {
   const value = amounts.value[candidate.key] ?? Math.abs(candidate.amount);
@@ -95,6 +106,27 @@ function confidenceLabel(confidence: MatchCandidate["confidence"]) {
   return "Low confidence";
 }
 
+function candidateSearchText(candidate: MatchCandidate) {
+  return [
+    candidate.voucher_name,
+    candidate.voucher_type,
+    candidate.source_type,
+    candidate.reference_number,
+    candidate.party_name,
+    candidate.party,
+    candidate.party_type,
+    candidate.posting_date,
+    candidate.reference_date,
+    candidate.amount,
+    candidate.currency,
+    confidenceLabel(candidate.confidence),
+    ...candidate.reasons,
+  ]
+    .filter((value) => value !== undefined && value !== null)
+    .join(" ")
+    .toLowerCase();
+}
+
 function toggleCandidate(candidate: MatchCandidate, checked: boolean) {
   if (checked && !selectedKeys.value.includes(candidate.key)) {
     selectedKeys.value = [...selectedKeys.value, candidate.key];
@@ -133,6 +165,7 @@ watch(
       (candidate) => candidate.rank === topRank && candidate.confidence === "high"
     );
     selectedKeys.value = topCandidates.length === 1 ? [topCandidates[0].key] : [];
+    search.value = "";
   },
   { immediate: true }
 );
@@ -144,7 +177,7 @@ watch(
       <div>
         <div class="text-base font-semibold text-bank-ink">Match</div>
         <div class="text-sm tabular-nums text-bank-muted">
-          {{ candidates.length }} candidates
+          {{ search ? `${filteredCandidates.length} of ${candidates.length}` : candidates.length }} candidates
         </div>
       </div>
       <Button variant="subtle" :loading="loading" @click="$emit('refresh')">
@@ -174,7 +207,26 @@ watch(
     />
 
     <template v-else>
-      <div class="bank-rec-scrollbar min-h-0 flex-1 overflow-auto">
+      <div class="border-b border-bank-line px-4 py-3">
+        <div class="relative">
+          <Search class="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-bank-muted" />
+          <input
+            v-model="search"
+            class="h-9 w-full rounded-md border border-bank-line bg-white pl-9 pr-3 text-sm outline-none focus:border-bank-accent focus:ring-2 focus:ring-blue-100"
+            type="search"
+            placeholder="Search documents, references, parties, dates, amounts"
+          />
+        </div>
+      </div>
+
+      <EmptyState
+        v-if="!filteredCandidates.length"
+        class="min-h-0 flex-1"
+        title="No candidates match search"
+        detail="Change the search term or refresh candidates."
+      />
+
+      <div v-else class="bank-rec-scrollbar min-h-0 flex-1 overflow-auto">
         <table class="min-w-full divide-y divide-bank-line text-sm">
           <thead class="sticky top-0 bg-gray-50 text-left text-xs font-medium uppercase tracking-wide text-bank-muted">
             <tr>
@@ -188,7 +240,7 @@ watch(
           </thead>
           <tbody class="divide-y divide-bank-line bg-white">
             <tr
-              v-for="candidate in candidates"
+              v-for="candidate in filteredCandidates"
               :key="candidate.key"
               :class="selectedKeys.includes(candidate.key) ? 'bg-bank-accent-50' : ''"
             >

--- a/bank_rec/src/env.d.ts
+++ b/bank_rec/src/env.d.ts
@@ -22,5 +22,5 @@ interface Window {
   allowed_roles?: string[];
   allowed_companies?: string[];
   settings?: Record<string, unknown>;
-  accounting_dimensions?: Record<string, unknown>[];
+  accounting_dimensions?: import("@/types/bankRec").AccountingDimension[];
 }

--- a/bank_rec/src/pages/CashCodingPage.vue
+++ b/bank_rec/src/pages/CashCodingPage.vue
@@ -79,6 +79,24 @@ const tableMinWidth = computed(
   () => `${1120 + accountingDimensions.value.length * 180}px`
 );
 
+function isBalanceSheetRootType(rootType?: string) {
+  return ["Asset", "Liability", "Equity"].includes(rootType || "");
+}
+
+const bankAccountIsBalanceSheet = computed(() => {
+  const bankAccount = store.selectedBankAccountDoc;
+  if (!bankAccount?.account) {
+    return false;
+  }
+  if (!bankAccount.account_report_type && !bankAccount.account_root_type) {
+    return true;
+  }
+  return (
+    bankAccount.account_report_type === "Balance Sheet" ||
+    isBalanceSheetRootType(bankAccount.account_root_type)
+  );
+});
+
 function defaultDimensionValues(dimensions: AccountingDimension[]) {
   return Object.fromEntries(
     dimensions.map((dimension) => [dimension.fieldname, dimension.default_value || ""])
@@ -113,13 +131,18 @@ function dimensionOptionLabel(option: DimensionOption) {
   return typeof displayValue === "string" ? displayValue : option.name;
 }
 
+function isBalanceSheetAccount(accountName: string) {
+  return isBalanceSheetRootType(accountByName.value[accountName]?.root_type);
+}
+
 function isProfitAndLossAccount(accountName: string) {
   return ["Income", "Expense"].includes(accountByName.value[accountName]?.root_type || "");
 }
 
 function isDimensionRequired(dimension: AccountingDimension, row: CashCodingRow) {
   return Boolean(
-    dimension.mandatory_for_bs ||
+    (dimension.mandatory_for_bs &&
+      (bankAccountIsBalanceSheet.value || isBalanceSheetAccount(row.account))) ||
       (isProfitAndLossAccount(row.account) && dimension.mandatory_for_pl)
   );
 }
@@ -128,6 +151,10 @@ function missingRequiredDimension(row: CashCodingRow) {
   return accountingDimensions.value.find(
     (dimension) => isDimensionRequired(dimension, row) && !row.dimensions[dimension.fieldname]
   );
+}
+
+function isDimensionRequiredInVisibleRows(dimension: AccountingDimension) {
+  return visibleRows.value.some((row) => isDimensionRequired(dimension, row));
 }
 
 function markDirty(name: string) {
@@ -292,15 +319,20 @@ async function submitSelected() {
     return;
   }
 
-  const rowMissingDimension = selectedRows.value.find((row) => missingRequiredDimension(row));
-  if (rowMissingDimension) {
-    const dimension = missingRequiredDimension(rowMissingDimension);
-    if (!dimension) {
-      return;
+  let rowMissingDimension: CashCodingRow | undefined;
+  let missingDimension: AccountingDimension | undefined;
+  for (const row of selectedRows.value) {
+    const dimension = missingRequiredDimension(row);
+    if (dimension) {
+      rowMissingDimension = row;
+      missingDimension = dimension;
+      break;
     }
+  }
+  if (rowMissingDimension && missingDimension) {
     rowErrors.value = {
       ...rowErrors.value,
-      [rowMissingDimension.transaction.name]: `${dimensionLabel(dimension)} is required.`,
+      [rowMissingDimension.transaction.name]: `${dimensionLabel(missingDimension)} is required.`,
     };
     pageError.value = "One or more selected rows are missing a required dimension.";
     return;
@@ -467,7 +499,7 @@ onBeforeRouteLeave(() => guardDiscard());
                 :key="dimension.fieldname"
                 class="w-44 px-3 py-3"
               >
-                {{ dimensionLabel(dimension) }}{{ dimension.mandatory_for_bs || dimension.mandatory_for_pl ? " *" : "" }}
+                {{ dimensionLabel(dimension) }}{{ isDimensionRequiredInVisibleRows(dimension) ? " *" : "" }}
               </th>
               <th class="w-[10%] px-3 py-3">Reference</th>
             </tr>

--- a/bank_rec/src/pages/CashCodingPage.vue
+++ b/bank_rec/src/pages/CashCodingPage.vue
@@ -121,7 +121,7 @@ function dimensionLabel(dimension: AccountingDimension) {
 }
 
 function dimensionDatalistId(dimension: AccountingDimension) {
-  return `cash-coding-dimension-${dimension.fieldname}`;
+  return `bank-coding-dimension-${dimension.fieldname}`;
 }
 
 function dimensionOptionLabel(option: DimensionOption) {
@@ -177,7 +177,7 @@ function guardDiscard() {
   if (!hasDirtyRows.value) {
     return true;
   }
-  return window.confirm("Discard unsaved cash coding changes?");
+  return window.confirm("Discard unsaved bank coding changes?");
 }
 
 async function replaceQuery() {
@@ -237,7 +237,7 @@ async function loadRows(options: { confirmDiscard?: boolean } = {}) {
       return;
     }
     pageError.value =
-      error instanceof Error ? error.message : "Unable to load cash coding rows.";
+      error instanceof Error ? error.message : "Unable to load bank coding rows.";
   } finally {
     if (loadRequestId.value === requestId) {
       loading.value = false;
@@ -363,7 +363,7 @@ async function submitSelected() {
     await store.loadBankAccounts();
   } catch (error) {
     pageError.value =
-      error instanceof Error ? error.message : "Unable to submit cash coding.";
+      error instanceof Error ? error.message : "Unable to submit bank coding.";
   } finally {
     submitting.value = false;
   }
@@ -409,7 +409,7 @@ onBeforeRouteLeave(() => guardDiscard());
 
     <div class="flex items-center gap-2 rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900">
       <TriangleAlert class="h-4 w-4 shrink-0 text-amber-500" />
-      Tax is not posted from cash coding.
+      Tax is not posted from bank coding.
     </div>
 
     <ErrorState
@@ -423,21 +423,21 @@ onBeforeRouteLeave(() => guardDiscard());
           v-model="bulkAccount"
           variant="outline"
           size="md"
-          list="cash-coding-accounts"
+          list="bank-coding-accounts"
           placeholder="Account"
         />
         <FormControl
           v-model="bulkCostCenter"
           variant="outline"
           size="md"
-          list="cash-coding-cost-centers"
+          list="bank-coding-cost-centers"
           placeholder="Cost center"
         />
         <FormControl
           v-model="bulkProject"
           variant="outline"
           size="md"
-          list="cash-coding-projects"
+          list="bank-coding-projects"
           placeholder="Project"
         />
         <FormControl
@@ -473,10 +473,10 @@ onBeforeRouteLeave(() => guardDiscard());
         </div>
       </div>
 
-      <LoadingState v-if="loading" label="Loading cash coding rows" />
+      <LoadingState v-if="loading" label="Loading bank coding rows" />
       <EmptyState
         v-else-if="!visibleRows.length"
-        title="No cash coding rows"
+        title="No bank coding rows"
         detail="Change filters or date range."
       />
       <div v-else class="bank-rec-scrollbar min-h-[360px] flex-1 overflow-auto lg:min-h-0">
@@ -545,7 +545,7 @@ onBeforeRouteLeave(() => guardDiscard());
                 <input
                   v-model="row.account"
                   class="h-9 w-full min-w-0 rounded-md border border-bank-line px-2 text-sm outline-none focus:border-bank-accent focus:ring-2 focus:ring-blue-100"
-                  list="cash-coding-accounts"
+                  list="bank-coding-accounts"
                   @input="markDirty(row.transaction.name)"
                 />
               </td>
@@ -572,7 +572,7 @@ onBeforeRouteLeave(() => guardDiscard());
                 <input
                   v-model="row.cost_center"
                   class="h-9 w-full min-w-0 rounded-md border border-bank-line px-2 text-sm outline-none focus:border-bank-accent focus:ring-2 focus:ring-blue-100"
-                  list="cash-coding-cost-centers"
+                  list="bank-coding-cost-centers"
                   @input="markDirty(row.transaction.name)"
                 />
               </td>
@@ -580,7 +580,7 @@ onBeforeRouteLeave(() => guardDiscard());
                 <input
                   v-model="row.project"
                   class="h-9 w-full min-w-0 rounded-md border border-bank-line px-2 text-sm outline-none focus:border-bank-accent focus:ring-2 focus:ring-blue-100"
-                  list="cash-coding-projects"
+                  list="bank-coding-projects"
                   @input="markDirty(row.transaction.name)"
                 />
               </td>
@@ -609,17 +609,17 @@ onBeforeRouteLeave(() => guardDiscard());
       </div>
     </section>
 
-    <datalist id="cash-coding-accounts">
+    <datalist id="bank-coding-accounts">
       <option v-for="row in accountOptions" :key="row.name" :value="row.name">
         {{ row.account_name || row.name }}
       </option>
     </datalist>
-    <datalist id="cash-coding-cost-centers">
+    <datalist id="bank-coding-cost-centers">
       <option v-for="row in costCenterOptions" :key="row.name" :value="row.name">
         {{ row.cost_center_name || row.name }}
       </option>
     </datalist>
-    <datalist id="cash-coding-projects">
+    <datalist id="bank-coding-projects">
       <option v-for="row in projectOptions" :key="row.name" :value="row.name">
         {{ row.project_name || row.name }}
       </option>
@@ -640,7 +640,7 @@ onBeforeRouteLeave(() => guardDiscard());
 
     <ReconcileProgressDialog
       :open="submitting"
-      title="Posting cash coding"
+      title="Posting bank coding"
       message="Posting valid rows and keeping failed rows visible."
     />
   </div>

--- a/bank_rec/src/pages/CashCodingPage.vue
+++ b/bank_rec/src/pages/CashCodingPage.vue
@@ -183,6 +183,7 @@ function guardDiscard() {
 async function replaceQuery() {
   await router.replace({
     path: route.path,
+    hash: route.hash || undefined,
     query: {
       company: store.selectedCompany || undefined,
       bank_account: store.selectedBankAccount || undefined,

--- a/bank_rec/src/pages/CashCodingPage.vue
+++ b/bank_rec/src/pages/CashCodingPage.vue
@@ -8,7 +8,12 @@ import LoadingState from "@/components/LoadingState.vue";
 import ReconcileProgressDialog from "@/components/ReconcileProgressDialog.vue";
 import { getCashCodingRows, submitCashCoding } from "@/services/api";
 import { useBankRecStore } from "@/stores/bankRec";
-import type { CashCodingRow, CreateOption } from "@/types/bankRec";
+import type {
+  AccountingDimension,
+  CashCodingRow,
+  CreateOption,
+  DimensionOption,
+} from "@/types/bankRec";
 import { formatDate, formatMoney, signedAmountClass } from "@/utils/format";
 import CheckCircle2 from "~icons/lucide/check-circle-2";
 import RefreshCcw from "~icons/lucide/refresh-cw";
@@ -24,6 +29,8 @@ const rows = ref<CashCodingRow[]>([]);
 const accountOptions = ref<CreateOption[]>([]);
 const costCenterOptions = ref<CreateOption[]>([]);
 const projectOptions = ref<CreateOption[]>([]);
+const accountingDimensions = ref<AccountingDimension[]>([]);
+const dimensionOptions = ref<Record<string, DimensionOption[]>>({});
 const selected = ref<string[]>([]);
 const dirtyRows = ref<Set<string>>(new Set());
 const rowErrors = ref<Record<string, string>>({});
@@ -35,6 +42,7 @@ const viewFilter = ref<ViewFilter>("all");
 const bulkAccount = ref("");
 const bulkCostCenter = ref("");
 const bulkProject = ref("");
+const bulkDimensions = ref<Record<string, string>>({});
 const viewFilterButtons = [
   { label: "All", value: "all" },
   { label: "Uncoded", value: "uncoded" },
@@ -64,6 +72,63 @@ const selectedRows = computed(() =>
 );
 
 const hasDirtyRows = computed(() => dirtyRows.value.size > 0);
+const accountByName = computed(() =>
+  Object.fromEntries(accountOptions.value.map((row) => [row.name, row]))
+);
+const tableMinWidth = computed(
+  () => `${1120 + accountingDimensions.value.length * 180}px`
+);
+
+function defaultDimensionValues(dimensions: AccountingDimension[]) {
+  return Object.fromEntries(
+    dimensions.map((dimension) => [dimension.fieldname, dimension.default_value || ""])
+  );
+}
+
+function normalizeCashCodingRow(
+  row: CashCodingRow,
+  dimensions: AccountingDimension[]
+): CashCodingRow {
+  return {
+    ...row,
+    dimensions: {
+      ...defaultDimensionValues(dimensions),
+      ...(row.dimensions || {}),
+    },
+  };
+}
+
+function dimensionLabel(dimension: AccountingDimension) {
+  return dimension.label || dimension.fieldname;
+}
+
+function dimensionDatalistId(dimension: AccountingDimension) {
+  return `cash-coding-dimension-${dimension.fieldname}`;
+}
+
+function dimensionOptionLabel(option: DimensionOption) {
+  const displayValue = Object.entries(option).find(
+    ([key, value]) => key !== "name" && typeof value === "string" && value
+  )?.[1];
+  return typeof displayValue === "string" ? displayValue : option.name;
+}
+
+function isProfitAndLossAccount(accountName: string) {
+  return ["Income", "Expense"].includes(accountByName.value[accountName]?.root_type || "");
+}
+
+function isDimensionRequired(dimension: AccountingDimension, row: CashCodingRow) {
+  return Boolean(
+    dimension.mandatory_for_bs ||
+      (isProfitAndLossAccount(row.account) && dimension.mandatory_for_pl)
+  );
+}
+
+function missingRequiredDimension(row: CashCodingRow) {
+  return accountingDimensions.value.find(
+    (dimension) => isDimensionRequired(dimension, row) && !row.dimensions[dimension.fieldname]
+  );
+}
 
 function markDirty(name: string) {
   const next = new Set(dirtyRows.value);
@@ -130,7 +195,11 @@ async function loadRows(options: { confirmDiscard?: boolean } = {}) {
     if (loadRequestId.value !== requestId) {
       return;
     }
-    rows.value = response.rows;
+    const responseDimensions =
+      response.options.accounting_dimensions || store.boot?.accounting_dimensions || [];
+    accountingDimensions.value = responseDimensions;
+    dimensionOptions.value = response.options.dimension_options || {};
+    rows.value = response.rows.map((row) => normalizeCashCodingRow(row, responseDimensions));
     accountOptions.value = response.options.accounts;
     costCenterOptions.value = response.options.cost_centers;
     projectOptions.value = response.options.projects;
@@ -196,6 +265,12 @@ function applyBulk() {
     if (bulkProject.value) {
       row.project = bulkProject.value;
     }
+    accountingDimensions.value.forEach((dimension) => {
+      const value = bulkDimensions.value[dimension.fieldname];
+      if (value) {
+        row.dimensions[dimension.fieldname] = value;
+      }
+    });
     markDirty(row.transaction.name);
   });
 }
@@ -214,6 +289,20 @@ async function submitSelected() {
       [missingAccount.transaction.name]: "Account is required.",
     };
     pageError.value = "One or more selected rows are missing an account.";
+    return;
+  }
+
+  const rowMissingDimension = selectedRows.value.find((row) => missingRequiredDimension(row));
+  if (rowMissingDimension) {
+    const dimension = missingRequiredDimension(rowMissingDimension);
+    if (!dimension) {
+      return;
+    }
+    rowErrors.value = {
+      ...rowErrors.value,
+      [rowMissingDimension.transaction.name]: `${dimensionLabel(dimension)} is required.`,
+    };
+    pageError.value = "One or more selected rows are missing a required dimension.";
     return;
   }
 
@@ -297,7 +386,7 @@ onBeforeRouteLeave(() => guardDiscard());
     />
 
     <section class="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-bank-line bg-white shadow-sm">
-      <div class="grid gap-3 border-b border-bank-line p-4 lg:grid-cols-[1fr_1fr_1fr_auto]">
+      <div class="grid gap-3 border-b border-bank-line p-4 sm:grid-cols-2 xl:grid-cols-4">
         <FormControl
           v-model="bulkAccount"
           variant="outline"
@@ -319,7 +408,16 @@ onBeforeRouteLeave(() => guardDiscard());
           list="cash-coding-projects"
           placeholder="Project"
         />
-        <Button variant="subtle" @click="applyBulk">Apply</Button>
+        <FormControl
+          v-for="dimension in accountingDimensions"
+          :key="dimension.fieldname"
+          v-model="bulkDimensions[dimension.fieldname]"
+          variant="outline"
+          size="md"
+          :list="dimensionDatalistId(dimension)"
+          :placeholder="dimensionLabel(dimension)"
+        />
+        <Button class="xl:justify-self-start" variant="subtle" @click="applyBulk">Apply</Button>
       </div>
 
       <div class="flex flex-col gap-3 border-b border-bank-line px-4 py-3 md:flex-row md:items-center md:justify-between">
@@ -350,7 +448,10 @@ onBeforeRouteLeave(() => guardDiscard());
         detail="Change filters or date range."
       />
       <div v-else class="bank-rec-scrollbar min-h-[360px] flex-1 overflow-auto lg:min-h-0">
-        <table class="w-full min-w-[1120px] table-fixed divide-y divide-bank-line text-sm">
+        <table
+          class="w-full table-fixed divide-y divide-bank-line text-sm"
+          :style="{ minWidth: tableMinWidth }"
+        >
           <thead class="sticky top-0 bg-gray-50 text-left text-xs font-medium uppercase tracking-wide text-bank-muted">
             <tr>
               <th class="w-9 px-3 py-3"></th>
@@ -361,6 +462,13 @@ onBeforeRouteLeave(() => guardDiscard());
               <th class="w-[18%] px-3 py-3">Contact</th>
               <th class="w-[13%] px-3 py-3">Cost center</th>
               <th class="w-[13%] px-3 py-3">Project</th>
+              <th
+                v-for="dimension in accountingDimensions"
+                :key="dimension.fieldname"
+                class="w-44 px-3 py-3"
+              >
+                {{ dimensionLabel(dimension) }}{{ dimension.mandatory_for_bs || dimension.mandatory_for_pl ? " *" : "" }}
+              </th>
               <th class="w-[10%] px-3 py-3">Reference</th>
             </tr>
           </thead>
@@ -444,6 +552,18 @@ onBeforeRouteLeave(() => guardDiscard());
                   @input="markDirty(row.transaction.name)"
                 />
               </td>
+              <td
+                v-for="dimension in accountingDimensions"
+                :key="dimension.fieldname"
+                class="px-3 py-3 align-top"
+              >
+                <input
+                  v-model="row.dimensions[dimension.fieldname]"
+                  class="h-9 w-full min-w-0 rounded-md border border-bank-line px-2 text-sm outline-none focus:border-bank-accent focus:ring-2 focus:ring-blue-100"
+                  :list="dimensionDatalistId(dimension)"
+                  @input="markDirty(row.transaction.name)"
+                />
+              </td>
               <td class="px-3 py-3 align-top">
                 <input
                   v-model="row.reference_number"
@@ -470,6 +590,19 @@ onBeforeRouteLeave(() => guardDiscard());
     <datalist id="cash-coding-projects">
       <option v-for="row in projectOptions" :key="row.name" :value="row.name">
         {{ row.project_name || row.name }}
+      </option>
+    </datalist>
+    <datalist
+      v-for="dimension in accountingDimensions"
+      :id="dimensionDatalistId(dimension)"
+      :key="dimension.fieldname"
+    >
+      <option
+        v-for="option in dimensionOptions[dimension.fieldname] || []"
+        :key="option.name"
+        :value="option.name"
+      >
+        {{ dimensionOptionLabel(option) }}
       </option>
     </datalist>
 

--- a/bank_rec/src/router/index.ts
+++ b/bank_rec/src/router/index.ts
@@ -17,9 +17,13 @@ export const router = createRouter({
       component: ReconcilePage,
     },
     {
-      path: "/cash-coding",
-      name: "Cash Coding",
+      path: "/bank-coding",
+      name: "Bank Coding",
       component: CashCodingPage,
+    },
+    {
+      path: "/cash-coding",
+      redirect: "/bank-coding",
     },
     {
       path: "/matched",

--- a/bank_rec/src/router/index.ts
+++ b/bank_rec/src/router/index.ts
@@ -23,7 +23,11 @@ export const router = createRouter({
     },
     {
       path: "/cash-coding",
-      redirect: "/bank-coding",
+      redirect: (to) => ({
+        path: "/bank-coding",
+        query: to.query,
+        hash: to.hash,
+      }),
     },
     {
       path: "/matched",

--- a/bank_rec/src/types/bankRec.ts
+++ b/bank_rec/src/types/bankRec.ts
@@ -1,3 +1,19 @@
+export interface AccountingDimension {
+  fieldname: string;
+  fieldtype?: string;
+  label?: string;
+  options?: string;
+  has_company_field?: boolean;
+  default_value?: string;
+  mandatory_for_bs?: boolean;
+  mandatory_for_pl?: boolean;
+}
+
+export interface DimensionOption {
+  name: string;
+  [key: string]: unknown;
+}
+
 export interface BootData {
   default_route: string;
   site_name: string;
@@ -8,7 +24,7 @@ export interface BootData {
   allowed_roles: string[];
   allowed_companies: string[];
   settings: Record<string, unknown>;
-  accounting_dimensions: Record<string, unknown>[];
+  accounting_dimensions: AccountingDimension[];
 }
 
 export interface BankAccount {
@@ -158,6 +174,8 @@ export interface CreateDefaultsResponse {
     mode_of_payments: CreateOption[];
     cost_centers: CreateOption[];
     projects: CreateOption[];
+    accounting_dimensions: AccountingDimension[];
+    dimension_options: Record<string, DimensionOption[]>;
   };
 }
 
@@ -200,6 +218,7 @@ export interface CashCodingRow {
   party: string;
   cost_center: string;
   project: string;
+  dimensions: Record<string, string>;
   reference_number: string;
   notes: string;
   suggested_rule?: { name: string; title: string } | null;
@@ -211,6 +230,8 @@ export interface CashCodingRowsResponse {
     accounts: CreateOption[];
     cost_centers: CreateOption[];
     projects: CreateOption[];
+    accounting_dimensions: AccountingDimension[];
+    dimension_options: Record<string, DimensionOption[]>;
   };
 }
 

--- a/bank_rec/src/types/bankRec.ts
+++ b/bank_rec/src/types/bankRec.ts
@@ -34,6 +34,8 @@ export interface BankAccount {
   account: string;
   company: string;
   currency?: string;
+  account_root_type?: string;
+  account_report_type?: string;
 }
 
 export type TransactionDirection = "deposit" | "withdrawal" | "unknown";

--- a/docs/bank-rec-modern-ui-design.md
+++ b/docs/bank-rec-modern-ui-design.md
@@ -8,7 +8,7 @@ The current tool must remain available and working as-is. The new experience wil
 
 ## Product Positioning
 
-This is not a 100% Xero parity project. The UI should borrow the parts of Xero that make daily work faster, especially the split-screen transaction flow and the cash-coding grid, but the accounting model must remain NexWave-native.
+This is not a 100% Xero parity project. The UI should borrow the parts of Xero that make daily work faster, especially the split-screen transaction flow and the bank-coding grid, but the accounting model must remain NexWave-native.
 
 Key model difference:
 
@@ -31,7 +31,7 @@ Rationale:
 - It is short enough to type and remember.
 - It reads like a product/workspace name, not a developer utility.
 - "Tool" is redundant in user navigation. The UI itself is the tool.
-- It leaves room for subroutes such as `/bank-rec/reconcile`, `/bank-rec/cash-coding`, `/bank-rec/matched`, and `/bank-rec/rules`.
+- It leaves room for subroutes such as `/bank-rec/reconcile`, `/bank-rec/bank-coding`, `/bank-rec/matched`, and `/bank-rec/rules`.
 
 No compatibility route:
 
@@ -44,8 +44,8 @@ No compatibility route:
 - Do not reuse the current modal-first UI as the primary interaction model.
 - Do not replace the proven reconciliation backend in the first version.
 - Do not implement transfers between bank accounts in MVP.
-- Do not implement split cash coding in MVP.
-- Do not implement tax-rate behavior for cash coding in MVP.
+- Do not implement split bank coding in MVP.
+- Do not implement tax-rate behavior for bank coding in MVP.
 - Do not introduce a Xero-style reconciliation-session model in MVP.
 - Do not expose customer-specific examples, names, URLs, or data in docs, tests, commits, or PR text.
 
@@ -54,7 +54,7 @@ No compatibility route:
 The new UI has three primary surfaces:
 
 1. Reconcile
-2. Cash Coding
+2. Bank Coding
 3. Review Matched
 
 Bank rules remain accessible through a minimal MVP list, with edit and delete handled by links to the existing Desk form. Settings are loaded behind the scenes and should not appear as an MVP navigation item until a user-facing settings workflow is designed.
@@ -65,7 +65,7 @@ Bank rules remain accessible through a minimal MVP list, with edit and delete ha
 - App screen label: `Bank Rec`.
 - Do not add `/bank-rec-tool` as a route or redirect.
 - Transfers are a later iteration, not MVP.
-- Cash coding splits are a later iteration, not MVP.
+- Bank coding splits are a later iteration, not MVP.
 - Tax coding is a later iteration after the accounting treatment is specified.
 - Reconciliation remains clearance-date based. No reconciliation-session model is planned for MVP.
 - The Update tab is included in MVP for bank-transaction metadata edits.
@@ -84,7 +84,7 @@ Suggested subroutes:
 
 ```text
 /bank-rec/reconcile
-/bank-rec/cash-coding
+/bank-rec/bank-coding
 /bank-rec/matched
 /bank-rec/rules
 ```
@@ -119,7 +119,7 @@ The `bank_rec` Python page serves the Vue app shell. The browser-visible URL rem
 Route state:
 
 - Persist `bank_account`, `from_date`, `to_date`, and the selected `bank_transaction` in the URL query where the current page uses them.
-- Restore those query values on hard refresh and direct subroute visits such as `/bank-rec/cash-coding`.
+- Restore those query values on hard refresh and direct subroute visits such as `/bank-rec/bank-coding`.
 - If a restored bank account or transaction is no longer permitted or no longer exists in the filtered result, show the normal empty or permission state and fall back to the first valid row only when that is safe.
 - Use route replace for frequent selection changes so browser Back remains useful.
 
@@ -387,13 +387,13 @@ Functional details:
 - Payment Entry creation must preserve multi-currency behavior.
 - Translate hidden voucher-type validation errors into the split-screen language. For example, show that a contact is required for the selected account instead of surfacing an internal Payment Entry party error.
 
-## Cash Coding Workflow
+## Bank Coding Workflow
 
 Goal: let users code many simple bank transactions in a grid and reconcile them in bulk.
 
 User flow:
 
-1. User opens `Cash Coding`.
+1. User opens `Bank Coding`.
 2. Grid loads unreconciled transactions suitable for coding.
 3. Bank rules can pre-fill account, party, cost center, project, and dimensions.
 4. User edits rows inline.
@@ -403,7 +403,7 @@ User flow:
 
 Mockup:
 
-![Cash coding grid](mockups/cash-coding-grid.svg)
+![Bank coding grid](mockups/bank-coding-grid.svg)
 
 MVP row fields:
 
@@ -429,8 +429,8 @@ MVP behavior:
 - Return row-level results.
 - Let users filter to uncoded, rule-suggested, errors, or selected rows.
 - Support bulk apply for selected rows, so account, party, cost center, project, dimensions, reference, and notes can be filled down before submit.
-- Treat tax coding as out of scope. The MVP cash-coding grid must not imply that taxable GST/BAS transactions are being posted tax-correctly.
-- Show a visible but compact cash-coding warning banner that tax is not posted from MVP cash coding. Do not render this as a filter chip. Users should use full voucher entry for taxable transactions until the tax phase exists.
+- Treat tax coding as out of scope. The MVP bank-coding grid must not imply that taxable GST/BAS transactions are being posted tax-correctly.
+- Show a visible but compact bank-coding warning banner that tax is not posted from MVP bank coding. Do not render this as a filter chip. Users should use full voucher entry for taxable transactions until the tax phase exists.
 - Block mixed-direction bulk apply unless the user narrows the selection to one direction or explicitly changes only direction-neutral fields.
 - Block submit for selected rows missing required client-side fields such as account. The backend must still return row-level errors for rows that become invalid after validation starts.
 - Confirm before discarding unsaved grid edits on refresh, filter changes, route changes, or bank-account changes.
@@ -498,7 +498,7 @@ Match candidate:
 }
 ```
 
-Cash coding row result:
+Bank coding row result:
 
 ```json
 {
@@ -514,7 +514,7 @@ Cash coding row result:
 Frontend:
 
 - Show toast for overall success or failure.
-- Show row-level errors in cash coding.
+- Show row-level errors in bank coding.
 - Keep failed rows selected after bulk submit.
 - Confirm before discarding unsaved grid edits.
 - Disable mutating buttons while the request is in flight.
@@ -522,8 +522,8 @@ Frontend:
 
 Backend:
 
-- Use savepoints for row-level cash coding failures.
-- Add idempotency or locking checks around simple match, create voucher, and cash coding submit so duplicate clicks cannot create duplicate allocations or duplicate vouchers.
+- Use savepoints for row-level bank coding failures.
+- Add idempotency or locking checks around simple match, create voucher, and bank coding submit so duplicate clicks cannot create duplicate allocations or duplicate vouchers.
 - Use the shared ABR logger module.
 - Use `frappe.log_error()` for critical failures after rollback and commit the error log.
 - Return structured errors suitable for table display.
@@ -533,7 +533,7 @@ Backend:
 Use realtime events for operations that may take longer than a few seconds:
 
 - Bulk unpaid invoice reconciliation
-- Cash coding bulk submit when row count is high
+- Bank coding bulk submit when row count is high
 - Rule preview for large date ranges
 
 Event names:
@@ -544,9 +544,9 @@ cash_coding_progress
 cash_coding_complete
 ```
 
-For existing bulk match flows, subscribe the new UI to the current `bulk_reconciliation_progress` event instead of changing the existing emitter. New cash-coding bulk work can add dedicated cash-coding events because that path does not exist in the old tool.
+For existing bulk match flows, subscribe the new UI to the current `bulk_reconciliation_progress` event instead of changing the existing emitter. New bank-coding bulk work can add dedicated bank-coding events because that path does not exist in the old tool.
 
-The frontend must mount `ReconcileProgressDialog.vue` for long-running match and cash-coding operations. Users should see progress, partial failures, completion, and retry-ready error states instead of a silent wait.
+The frontend must mount `ReconcileProgressDialog.vue` for long-running match and bank-coding operations. Users should see progress, partial failures, completion, and retry-ready error states instead of a silent wait.
 
 ## Build And Install
 
@@ -581,8 +581,8 @@ Python tests:
 - Match candidate response shape.
 - Submit match against regular voucher.
 - Submit match against unpaid invoices.
-- Cash coding creates Journal Entry and reconciles Bank Transaction.
-- Cash coding returns row-level errors without rolling back successful rows.
+- Bank coding creates Journal Entry and reconciles Bank Transaction.
+- Bank coding returns row-level errors without rolling back successful rows.
 - Unreconcile behavior remains unchanged.
 - Statement summary does not return a `difference` value unless statement closing balance is supplied.
 - Unreconcile and cancel flows respect Accounting Period and standard document validation.
@@ -595,11 +595,11 @@ Frontend tests:
   - Reconcile split-screen loading.
 - Match submit.
 - Create voucher submit.
-- Cash coding row validation.
+- Bank coding row validation.
 - Empty and first-run states for no bank accounts, no selected transaction, no unreconciled rows, and no match candidates.
-- Double-submit prevention for match, create, update, cash coding, and unreconcile.
+- Double-submit prevention for match, create, update, bank coding, and unreconcile.
 - Stale async response discard while moving quickly between transactions.
-- Unsaved cash-coding edit discard confirmation.
+- Unsaved bank-coding edit discard confirmation.
 - Responsive layout.
 
 Manual QA:
@@ -648,14 +648,14 @@ Phase 3: MVP create voucher flow
 - Add "Edit in Full Page" secondary action that saves current values as a Draft voucher and opens it in Desk in a new browser tab.
 - Exclude bank-account transfers from the create flow in MVP.
 
-Phase 4: MVP Cash Coding
+Phase 4: MVP Bank Coding
 
 - Add editable grid.
 - Add rule suggestion preview.
 - Add bulk apply for selected rows.
 - Add row-level validation.
 - Add confirm-on-discard for unsaved grid edits.
-- Add progress dialog subscription for long-running cash-coding submit.
+- Add progress dialog subscription for long-running bank-coding submit.
 - Add bulk Journal Entry creation and reconciliation.
 - Support one coded Journal Entry per Bank Transaction.
 - Exclude split coding in MVP.
@@ -683,12 +683,12 @@ Phase 7: Later iteration, transfers
 
 Phase 8: Later iteration, tax coding
 
-- Define accounting treatment for tax-inclusive and tax-exclusive cash coding.
+- Define accounting treatment for tax-inclusive and tax-exclusive bank coding.
 - Add tax templates, tax accounts, and validation rules after the treatment is approved.
 - Add test cases for tax rounding, reversals, and basic taxable spend and receive-money coding.
 - Consider adding a tax field to bank rules only after the tax posting model is approved.
 
-Phase 9: Later iteration, split cash coding
+Phase 9: Later iteration, split bank coding
 
 - Allow one Bank Transaction to be split across multiple coding lines.
 - Validate that split totals equal the bank transaction amount before posting.
@@ -698,7 +698,7 @@ Phase 10: Later iteration, match adjustments and bank fees
 
 - Allow a small adjustment line while matching an otherwise valid voucher.
 - Support bank fees, FX cents, and minor rounding differences without forcing users into a separate manual document.
-- Reuse the same validation rules as cash coding and voucher creation.
+- Reuse the same validation rules as bank coding and voucher creation.
 
 Phase 11: Later iteration, attachments and receipt capture
 
@@ -712,7 +712,7 @@ Risk: duplicate business logic between old and new UI.
 
 Mitigation: new UI calls backend facade methods that reuse existing ABR functions.
 
-Risk: cash coding posts incorrect accounting entries at speed.
+Risk: bank coding posts incorrect accounting entries at speed.
 
 Mitigation: MVP supports Journal Entry coding only, validates every row server-side, and avoids tax behavior until designed.
 

--- a/docs/bank-rec-mvp-implementation-plan.md
+++ b/docs/bank-rec-mvp-implementation-plan.md
@@ -13,14 +13,14 @@ Build through Phase 5 only:
 1. MVP shell and read-only Reconcile
 2. MVP match flow
 3. MVP create voucher flow
-4. MVP Cash Coding
+4. MVP Bank Coding
 5. MVP matched review and hardening
 
 Out of MVP:
 
 - `/bank-rec-tool` route or redirect.
 - Transfers.
-- Split cash coding.
+- Split bank coding.
 - Tax coding.
 - Statement-balance Difference card unless a statement closing balance is supplied.
 - Reconciliation-session model.
@@ -50,13 +50,13 @@ Status values:
 | Phase 1: Shell and read-only Reconcile | Complete | Route app, permission facade, read-only APIs, minimal Rules list, frontend build |
 | Phase 2: Match flow | Complete | Match candidates, Update tab, submit match, duplicate-submit guard |
 | Phase 3: Create voucher flow | Complete | Create tab, Journal Entry submit, Payment Entry draft handoff, full-page edit |
-| Phase 4: Cash Coding | Complete | Grid, bulk apply, row-level Journal Entry submit, discard guards |
+| Phase 4: Bank Coding | Complete | Grid, bulk apply, row-level Journal Entry submit, discard guards |
 | Phase 5: Matched review and hardening | Complete | Tests, build, route probes, Chrome smoke, incremental commits, and PR are complete |
 
 ## Resolved Scope Decisions From Final Review
 
 - Build the `Update` tab in MVP. It edits Bank Transaction metadata only, such as reference number, party type, and party.
-- Ship a minimal `Rules` page in MVP because create flow can save a bank rule and cash coding can consume rule suggestions. The MVP page is list, search, and "Open in Desk"; it is not a full rules manager.
+- Ship a minimal `Rules` page in MVP because create flow can save a bank rule and bank coding can consume rule suggestions. The MVP page is list, search, and "Open in Desk"; it is not a full rules manager.
 - Hide `Settings` from MVP navigation. Backend settings can still load through `get_boot`.
 - Include `Mode of Payment` in the Create flow when the inferred Payment Entry path requires it.
 
@@ -67,12 +67,12 @@ These requirements apply to every implementation phase.
 UX states:
 
 - Every page and panel must have explicit loading, empty, error, and partial-failure states.
-- Handle first-run cases: no permitted bank accounts, no selected transaction, zero unreconciled rows, no match candidates, no cash-coding rows, and no matched transactions.
+- Handle first-run cases: no permitted bank accounts, no selected transaction, zero unreconciled rows, no match candidates, no bank-coding rows, and no matched transactions.
 - Empty states should give the next useful action, such as changing filters, choosing another bank account, or using Create when no match candidates exist.
 
 Async safety:
 
-- Use the `Date.now()` request-id discard pattern for transaction context, match candidates, create defaults, update metadata refreshes, cash-coding row reloads, and any other selection-dependent async call.
+- Use the `Date.now()` request-id discard pattern for transaction context, match candidates, create defaults, update metadata refreshes, bank-coding row reloads, and any other selection-dependent async call.
 - Never render async results for a Bank Transaction that is no longer selected.
 
 Route state:
@@ -86,15 +86,15 @@ Route state:
 Mutating actions:
 
 - Disable mutating buttons while a submit is in flight.
-- Backend methods for simple match, create voucher, update metadata, cash coding submit, and unreconcile must recheck current document state before writing.
+- Backend methods for simple match, create voucher, update metadata, bank coding submit, and unreconcile must recheck current document state before writing.
 - Add idempotency or locking checks where duplicate clicks could create duplicate allocations, duplicate vouchers, or duplicate Journal Entries.
 - Return structured errors that can be displayed in the active panel without exposing hidden voucher internals.
 
 Progress and long jobs:
 
-- Mount `ReconcileProgressDialog.vue` for any match, create, draft handoff, or cash-coding operation that returns a background job or may take longer than a few seconds.
+- Mount `ReconcileProgressDialog.vue` for any match, create, draft handoff, or bank-coding operation that returns a background job or may take longer than a few seconds.
 - Subscribe to `bulk_reconciliation_progress` for reused bulk reconciliation paths.
-- Subscribe to `cash_coding_progress` and `cash_coding_complete` for new cash-coding background paths.
+- Subscribe to `cash_coding_progress` and `cash_coding_complete` for new bank-coding background paths.
 
 Selection and auto-advance:
 
@@ -104,10 +104,10 @@ Selection and auto-advance:
 
 Unsaved edits:
 
-- Confirm before discarding unsaved cash-coding edits on refresh, filter changes, bank-account changes, route changes, or browser navigation.
+- Confirm before discarding unsaved bank-coding edits on refresh, filter changes, bank-account changes, route changes, or browser navigation.
 - Do not rely on "preserve edits where practical" as the safety model. If edits cannot be preserved, ask before discarding them.
 
-Cash-coding validation:
+Bank-coding validation:
 
 - Prevent mixed-direction bulk apply when the field being applied changes accounting meaning by direction. Allow direction-neutral fields such as cost center, project, dimensions, reference, and notes.
 - Block submit client-side when selected rows are missing required fields such as account.
@@ -218,7 +218,7 @@ Frontend and route tasks:
 - Add `add_to_apps_screen` entry with label `Bank Rec`.
 - Add route rule for `/bank-rec` and `/bank-rec/<path:app_path>`.
 - Do not add `/bank-rec-tool`.
-- Implement app shell with Reconcile, Cash Coding, Matched, and Rules navigation.
+- Implement app shell with Reconcile, Bank Coding, Matched, and Rules navigation.
 - Do not show Settings in MVP navigation.
 - Implement bank account and date filters.
 - Implement URL query sync and restore for bank account, date range, and selected Bank Transaction.
@@ -262,7 +262,7 @@ Progress notes:
 - Added hook entries for the Apps screen label `Bank Rec` and `/bank-rec` route rules. No `/bank-rec-tool` route was added.
 - Added `bank_rec/` Vue 3, TypeScript, Vite, Pinia, Vue Router, Tailwind, and Frappe UI frontend package.
 - Pinned `frappe-ui` to `1.0.0-beta.3` and used a local alias helper only for optional development checkouts. No submodule was added.
-- Implemented app navigation for Reconcile, Cash Coding, Matched, and Rules. Settings is not shown.
+- Implemented app navigation for Reconcile, Bank Coding, Matched, and Rules. Settings is not shown.
 - Implemented bank account, date, and status filters with URL query sync for `bank_account`, `from_date`, `to_date`, `status`, and `bank_transaction`.
 - Implemented read-only Reconcile split view with transaction list, summary cards, selected transaction detail panel, and linked payment display.
 - Implemented minimal Rules page with bank account filter, search, and `Open` action to Desk in a new tab.
@@ -456,7 +456,7 @@ Commands run:
 - `bench --site demo.localhost run-tests --app advanced_bank_reconciliation --module advanced_bank_reconciliation.api.test_bank_rec`
 - `yarn build`
 
-## Phase 4: MVP Cash Coding
+## Phase 4: MVP Bank Coding
 
 Status: Complete
 
@@ -471,7 +471,7 @@ Backend tasks:
 - Create one Journal Entry per coded Bank Transaction.
 - Use savepoints so valid rows can post when other rows fail.
 - Return row-level success and error results.
-- Add cash-coding realtime events if row count makes background processing necessary.
+- Add bank-coding realtime events if row count makes background processing necessary.
 - Do not implement tax posting.
 - Do not implement split coding.
 - Do not implement transfers.
@@ -486,14 +486,14 @@ Frontend tasks:
 - Confirm before discarding unsaved edits on refresh, filter changes, bank-account changes, route changes, or browser navigation.
 - Prevent mixed-direction bulk apply for direction-sensitive fields.
 - Block submit when selected rows are missing required fields such as account.
-- Mount progress dialog and subscribe to cash-coding progress events when the backend returns a job.
-- Disable submit while cash-coding submit is in flight.
+- Mount progress dialog and subscribe to bank-coding progress events when the backend returns a job.
+- Disable submit while bank-coding submit is in flight.
 - Keep failed rows selected after submit.
 - Show row-level errors.
 
 Tests:
 
-- Cash coding creates Journal Entry and reconciles Bank Transaction.
+- Bank coding creates Journal Entry and reconciles Bank Transaction.
 - Row-level errors do not roll back successful rows.
 - Required account validation.
 - Permission rejection for cross-company rows.
@@ -501,7 +501,7 @@ Tests:
 - Split rows are rejected in MVP.
 - Mixed-direction bulk apply guard.
 - Unsaved edit discard confirmation.
-- Duplicate submit guard for cash coding.
+- Duplicate submit guard for bank coding.
 
 Acceptance:
 
@@ -510,21 +510,21 @@ Acceptance:
 - Invalid rows remain visible with row-level errors.
 - Selected rows missing required account are blocked before submit, while backend row-level errors still handle late validation failures.
 - Bulk apply speeds repeated coding.
-- UI clearly indicates tax is not handled by MVP cash coding.
+- UI clearly indicates tax is not handled by MVP bank coding.
 
 Progress notes:
 
 - Added `advanced_bank_reconciliation/api/cash_coding.py` with `get_cash_coding_rows`, `preview_cash_coding`, and `submit_cash_coding`.
-- Cash coding rows reuse unreconciled Bank Transaction data and include company-scoped account, cost center, and project options.
+- Bank coding rows reuse unreconciled Bank Transaction data and include company-scoped account, cost center, and project options.
 - Submit creates one Journal Entry per selected Bank Transaction through the existing ABR Journal Entry helper and reconciles via the existing clearance-date behavior.
 - Row-level savepoints allow valid rows to post even when other rows fail validation.
 - Backend validates bank account access, Bank Transaction access, account company, ledger account status, required account, contact requirements for receivable or payable accounts, and locks each Bank Transaction before posting.
-- The frontend Cash Coding page now has bank account and date filters, row selection, editable account/contact/cost center/project/reference fields, account/cost center/project datalist options, filter chips, row errors, and selected-row submit.
-- Added a distinct amber warning: `Tax is not posted from cash coding.`
+- The frontend Bank Coding page now has bank account and date filters, row selection, editable account/contact/cost center/project/reference fields, account/cost center/project datalist options, filter chips, row errors, and selected-row submit.
+- Added a distinct amber warning: `Tax is not posted from bank coding.`
 - Bulk apply supports account, cost center, and project. It blocks account bulk-apply across mixed money directions while allowing neutral fields.
 - Unsaved edits are guarded on refresh, filter changes, bank-account changes, route changes, and browser navigation.
-- Cash-coding row loads use the request-id stale response discard pattern.
-- Cash-coding submit opens `ReconcileProgressDialog.vue` while rows are being posted.
+- Bank-coding row loads use the request-id stale response discard pattern.
+- Bank-coding submit opens `ReconcileProgressDialog.vue` while rows are being posted.
 - Successful rows are removed from the grid after submit. Failed rows remain visible with row-level errors.
 - Tax posting, split coding, and transfers are not implemented in MVP.
 - Backend tests cover row loading, successful Journal Entry coding, and row-level partial failure.
@@ -565,7 +565,7 @@ Tests:
 - Unreconcile and cancel linked document.
 - Accounting Period locked behavior.
 - Existing unreconcile behavior remains unchanged.
-- Browser tests for Reconcile, Match, Update, Create, Cash Coding, Rules, Matched, route refresh restore, progress dialog, and responsive layout.
+- Browser tests for Reconcile, Match, Update, Create, Bank Coding, Rules, Matched, route refresh restore, progress dialog, and responsive layout.
 
 Manual QA:
 
@@ -602,18 +602,18 @@ Progress notes:
 - Old Desk tool route probe redirects Guest to log in, which confirms the route still resolves and has not been removed.
 - Chrome plugin verification was attempted after the user requested `@chrome`, but the local Chrome bridge failed before a browser session could be created. Tool discovery did not expose another Chrome control tool, and the installation list did not include a Chrome plugin candidate. Authenticated Chrome smoke remains blocked until the local Chrome plugin bridge is available.
 - Chrome plugin setup initially failed before session setup, then succeeded after the updated plugin version was available on June 21, 2026.
-- Chrome smoke opened `http://demo.localhost:8000/bank-rec`, confirmed redirect to `/bank-rec/reconcile`, verified Reconcile, Cash Coding, Matched, and Rules pages load in the authenticated browser session, and found no console errors.
-- Chrome smoke surfaced a small page-title issue where Cash Coding rendered as `CashCoding`; fixed in `bank_rec/src/router/index.ts` and rechecked in Chrome.
+- Chrome smoke opened `http://demo.localhost:8000/bank-rec`, confirmed redirect to `/bank-rec/reconcile`, verified Reconcile, Bank Coding, Matched, and Rules pages load in the authenticated browser session, and found no console errors.
+- Chrome smoke surfaced a small page-title issue where Bank Coding rendered as `CashCoding`; fixed in `bank_rec/src/router/index.ts` and rechecked in Chrome.
 - Authenticated Chrome workflow verification on `demo.localhost` used isolated `BRCHROME` fixture rows and exercised:
   - Create Journal Entry from a withdrawal and reconcile it.
   - Create Payment Entry from a customer deposit and reconcile it.
   - Match one Bank Transaction against two submitted Payment Entries.
   - Match one Bank Transaction against an unpaid Sales Invoice.
-  - Cash Coding missing-account validation, then successful cash coding submission.
+  - Bank Coding missing-account validation, then successful bank coding submission.
   - Update tab metadata update for reference and party fields.
   - Edit in Full Page draft handoff, with Bank Rec remaining on the same selected route and a Draft Journal Entry created in Desk.
   - Matched review, linked voucher visibility, unreconcile confirmation modal, and unreconcile-only completion.
-- Database verification after the Chrome workflow confirmed the JE, PE, multi-PE, unpaid invoice, and cash-coding transactions were reconciled with the expected linked documents, the update row stayed unreconciled with metadata saved, the draft handoff created a draft Journal Entry, and the unreconcile-only row returned to `Unreconciled`.
+- Database verification after the Chrome workflow confirmed the JE, PE, multi-PE, unpaid invoice, and bank-coding transactions were reconciled with the expected linked documents, the update row stayed unreconciled with metadata saved, the draft handoff created a draft Journal Entry, and the unreconcile-only row returned to `Unreconciled`.
 - No site credential changes were made.
 - Release type was confirmed as `feat`, and local incremental commits were created on branch `feat/bank-rec-route-app`.
 - Generated Bank Rec build output is intentionally ignored and not part of the final branch diff.
@@ -645,15 +645,15 @@ Commands run:
 - Update tab works for Bank Transaction metadata.
 - Create voucher flow works.
 - Edit in Full Page preserves entered create values by opening a Draft voucher in a new tab, keeps the Bank Rec tab state intact, and does not reconcile until the user completes reconciliation through the normal Bank Rec flow.
-- Cash Coding works for non-tax simple coding.
+- Bank Coding works for non-tax simple coding.
 - Minimal Rules list works and opens Desk for edit or delete.
 - Settings is hidden from MVP navigation.
 - Matched review and unreconcile work.
-- Long-running match and cash-coding actions show progress.
+- Long-running match and bank-coding actions show progress.
 - Mutating actions have duplicate-submit guards.
 - Selection-dependent async calls discard stale responses.
 - Hard refresh restores route filters and selected Bank Transaction where permitted.
-- Cash-coding unsaved edits require confirmation before discard.
+- Bank-coding unsaved edits require confirmation before discard.
 - Summary cards do not show Difference without statement closing balance.
 - Tax, transfers, splits, and reconciliation-session model remain out of MVP.
 - Python tests pass.
@@ -668,6 +668,6 @@ Track these after MVP completion:
 - Phase 6: Statement balance check.
 - Phase 7: Transfers.
 - Phase 8: Tax coding.
-- Phase 9: Split cash coding.
+- Phase 9: Split bank coding.
 - Phase 10: Match adjustments and bank fees.
 - Phase 11: Attachments and receipt capture.

--- a/docs/mockups/bank-coding-grid.svg
+++ b/docs/mockups/bank-coding-grid.svg
@@ -4,7 +4,7 @@
   <text x="32" y="40" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="700" fill="#1f2937">Bank Rec</text>
   <text x="186" y="39" font-family="Inter, Arial, sans-serif" font-size="13" fill="#4b5563">Reconcile</text>
   <rect x="286" y="18" width="116" height="32" rx="6" fill="#edf2ff"/>
-  <text x="312" y="39" font-family="Inter, Arial, sans-serif" font-size="13" fill="#1f4ed8">Cash Coding</text>
+  <text x="312" y="39" font-family="Inter, Arial, sans-serif" font-size="13" fill="#1f4ed8">Bank Coding</text>
   <text x="432" y="39" font-family="Inter, Arial, sans-serif" font-size="13" fill="#4b5563">Matched</text>
   <text x="522" y="39" font-family="Inter, Arial, sans-serif" font-size="13" fill="#4b5563">Rules</text>
   <rect x="32" y="88" width="1376" height="76" rx="8" fill="#ffffff" stroke="#e5e7eb"/>
@@ -28,7 +28,7 @@
   <rect x="384" y="202" width="96" height="28" rx="14" fill="#f3f4f6"/>
   <text x="432" y="221" font-family="Inter, Arial, sans-serif" font-size="12" fill="#374151" text-anchor="middle">Selected</text>
   <rect x="512" y="197" width="280" height="38" rx="6" fill="#fff7ed" stroke="#fed7aa"/>
-  <text x="652" y="221" font-family="Inter, Arial, sans-serif" font-size="12" font-weight="700" fill="#9a3412" text-anchor="middle">Tax is not posted from cash coding</text>
+  <text x="652" y="221" font-family="Inter, Arial, sans-serif" font-size="12" font-weight="700" fill="#9a3412" text-anchor="middle">Tax is not posted from bank coding</text>
   <text x="1170" y="222" font-family="Inter, Arial, sans-serif" font-size="13" fill="#374151">Selected total: $525.00</text>
   <rect x="32" y="272" width="1376" height="596" rx="8" fill="#ffffff" stroke="#e5e7eb"/>
   <rect x="32" y="272" width="1376" height="42" rx="8" fill="#f9fafb"/>

--- a/docs/mockups/reconcile-split-view.svg
+++ b/docs/mockups/reconcile-split-view.svg
@@ -4,7 +4,7 @@
   <text x="32" y="40" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="700" fill="#1f2937">Bank Rec</text>
   <rect x="184" y="18" width="96" height="32" rx="6" fill="#edf2ff"/>
   <text x="208" y="39" font-family="Inter, Arial, sans-serif" font-size="13" fill="#1f4ed8">Reconcile</text>
-  <text x="310" y="39" font-family="Inter, Arial, sans-serif" font-size="13" fill="#4b5563">Cash Coding</text>
+  <text x="310" y="39" font-family="Inter, Arial, sans-serif" font-size="13" fill="#4b5563">Bank Coding</text>
   <text x="430" y="39" font-family="Inter, Arial, sans-serif" font-size="13" fill="#4b5563">Matched</text>
   <text x="520" y="39" font-family="Inter, Arial, sans-serif" font-size="13" fill="#4b5563">Rules</text>
   <rect x="32" y="88" width="1376" height="76" rx="8" fill="#ffffff" stroke="#e5e7eb"/>


### PR DESCRIPTION
## Summary
- add shared accounting dimension metadata for bank rec Create and Cash Coding flows
- render custom accounting dimension fields with defaults and required validation
- add client-side search to the Match candidate table

## Tests
- env/bin/python -m py_compile apps/advanced_bank_reconciliation/advanced_bank_reconciliation/api/accounting_dimensions.py apps/advanced_bank_reconciliation/advanced_bank_reconciliation/api/cash_coding.py apps/advanced_bank_reconciliation/advanced_bank_reconciliation/api/create_voucher.py apps/advanced_bank_reconciliation/advanced_bank_reconciliation/api/test_bank_rec.py
- yarn build
- bench --site demo.localhost run-tests --app advanced_bank_reconciliation --module advanced_bank_reconciliation.api.test_bank_rec --case TestBankRecPhaseThreeAPI
- bench --site demo.localhost run-tests --app advanced_bank_reconciliation --module advanced_bank_reconciliation.api.test_bank_rec --case TestBankRecPhaseFourAPI
- Chrome smoke on demo.localhost for Match search, Create dimensions, and Cash Coding dimensions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added accounting-dimensions support for **bank coding** and voucher creation.
  * Users can enter dimension values dynamically; required dimensions are indicated and validated.
  * Match candidates now include a search box with filtered results.
  * Navigation and routes now focus on **bank coding** (instead of cash coding).
* **Bug Fixes**
  * Bank-coding rows now consistently carry a `dimensions` object.
  * Submission is blocked when required dimensions are missing, and selections respect the current filtered candidate list. 
* **Documentation**
  * Updated the bank-reconciliation modern UI and MVP plan to align terminology and bank-coding workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->