### PR TITLE
fix: align Payment Entry bank account with Bank Transaction

### DIFF
--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/advance_bank_reconciliation_tool.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/advance_bank_reconciliation_tool.py
@@ -639,6 +639,8 @@ def create_payment_entry_bts(
 	pe.posting_date = posting_date
 	pe.paid_from = party_account if payment_type == "Receive" else bank_account
 	pe.paid_to = party_account if payment_type == "Pay" else bank_account
+	pe.bank_account = bank_transaction.bank_account
+	pe.set_bank_account_data()
 	pe.paid_from_account_currency = party_currency if payment_type == "Receive" else bank_currency
 	pe.paid_to_account_currency = party_currency if payment_type == "Pay" else bank_currency
 	pe.paid_amount = amount_in_party_currency if payment_type == "Receive" else amt_in_bank_acc_currency
@@ -2283,6 +2285,7 @@ def create_payment_entry_for_invoice(invoice_doc, bank_transaction, allocated_am
 		invoice_doc.doctype,
 		invoice_doc.name,
 		party_amount=signed_allocated_amount,
+		bank_account=bank_gl_account,
 	)
 
 	# Set the correct bank account based on payment type
@@ -2290,6 +2293,8 @@ def create_payment_entry_for_invoice(invoice_doc, bank_transaction, allocated_am
 		payment_entry.paid_to = bank_gl_account
 	else:  # Pay
 		payment_entry.paid_from = bank_gl_account
+	payment_entry.bank_account = bank_account_doc.name
+	payment_entry.set_bank_account_data()
 
 	# Collapse Payment Terms rows, strip deductions, and lock paid amounts
 	# to the caller's allocation. See helper for the full rationale.

--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/tests/test_payment_entry_bank_account.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/tests/test_payment_entry_bank_account.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2026, HighFlyer and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from advanced_bank_reconciliation.api.create_voucher import (
+	create_voucher_draft_from_transaction,
+	create_voucher_from_transaction,
+)
+from advanced_bank_reconciliation.advanced_bank_reconciliation.doctype.advance_bank_reconciliation_tool.advance_bank_reconciliation_tool import (
+	create_payment_entry_for_invoice,
+)
+
+from .fixtures import (
+	TEST_COMPANY,
+	TEST_CUSTOMER,
+	TEST_SUPPLIER,
+	create_test_bank_transaction,
+	create_test_purchase_invoice,
+	create_test_sales_invoice,
+	ensure_bank_account_for_company,
+	setup_abr_test_data,
+)
+
+
+class TestPaymentEntryBankAccount(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		cls.bank_account = setup_abr_test_data(TEST_COMPANY)
+		cls.unrelated_bank_account = ensure_bank_account_for_company(TEST_COMPANY)
+		frappe.db.commit()
+
+		selected = frappe.get_doc("Bank Account", cls.bank_account)
+		selected.bank_account_no = "_ABR-SELECTED-001"
+		selected.is_default = 0
+		selected.save(ignore_permissions=True)
+
+		unrelated = frappe.get_doc("Bank Account", cls.unrelated_bank_account)
+		unrelated.bank_account_no = "_ABR-UNRELATED-002"
+		unrelated.is_default = 1
+		unrelated.save(ignore_permissions=True)
+
+	def assert_transaction_bank_account(self, payment_entry, bank_side_field):
+		selected = frappe.get_doc("Bank Account", self.bank_account)
+		selected_ledger = frappe.get_doc("Account", selected.account)
+		self.assertEqual(payment_entry.bank_account, selected.name)
+		self.assertEqual(payment_entry.bank, selected.bank)
+		self.assertEqual(payment_entry.bank_account_no, selected.bank_account_no)
+		self.assertEqual(payment_entry.get(bank_side_field), selected.account)
+		self.assertEqual(
+			payment_entry.get(f"{bank_side_field}_account_currency"),
+			selected_ledger.account_currency,
+		)
+		self.assertEqual(
+			payment_entry.get(f"{bank_side_field}_account_type"),
+			selected_ledger.account_type,
+		)
+
+	def test_invoice_payment_uses_transaction_bank_account(self):
+		invoice = create_test_sales_invoice(outstanding=125)
+		bank_transaction = create_test_bank_transaction(self.bank_account, deposit=125)
+
+		payment_entry = create_payment_entry_for_invoice(
+			invoice_doc=invoice,
+			bank_transaction=bank_transaction,
+			allocated_amount=125,
+			payment_type="Receive",
+			party_type="Customer",
+			party=invoice.customer,
+		)
+
+		self.assert_transaction_bank_account(payment_entry, "paid_to")
+
+	def test_invoice_supplier_payment_uses_transaction_bank_account(self):
+		invoice = create_test_purchase_invoice(outstanding=90)
+		bank_transaction = create_test_bank_transaction(self.bank_account, withdrawal=90)
+
+		payment_entry = create_payment_entry_for_invoice(
+			invoice_doc=invoice,
+			bank_transaction=bank_transaction,
+			allocated_amount=90,
+			payment_type="Pay",
+			party_type="Supplier",
+			party=invoice.supplier,
+		)
+
+		self.assert_transaction_bank_account(payment_entry, "paid_from")
+
+	def test_direct_customer_payment_uses_transaction_bank_account(self):
+		bank_transaction = create_test_bank_transaction(self.bank_account, deposit=35)
+
+		result = create_voucher_draft_from_transaction(
+			bank_transaction.name,
+			{
+				"party_type": "Customer",
+				"party": TEST_CUSTOMER,
+				"reference_date": bank_transaction.date,
+				"posting_date": bank_transaction.date,
+			},
+		)
+
+		payment_entry = frappe.get_doc("Payment Entry", result["voucher_name"])
+		self.assert_transaction_bank_account(payment_entry, "paid_to")
+
+	def test_direct_supplier_payment_uses_transaction_bank_account(self):
+		bank_transaction = create_test_bank_transaction(self.bank_account, withdrawal=40)
+
+		result = create_voucher_draft_from_transaction(
+			bank_transaction.name,
+			{
+				"party_type": "Supplier",
+				"party": TEST_SUPPLIER,
+				"reference_date": bank_transaction.date,
+				"posting_date": bank_transaction.date,
+			},
+		)
+
+		payment_entry = frappe.get_doc("Payment Entry", result["voucher_name"])
+		self.assert_transaction_bank_account(payment_entry, "paid_from")
+
+	def test_submitted_direct_payment_uses_transaction_bank_account(self):
+		bank_transaction = create_test_bank_transaction(self.bank_account, deposit=45)
+
+		result = create_voucher_from_transaction(
+			bank_transaction.name,
+			{
+				"party_type": "Customer",
+				"party": TEST_CUSTOMER,
+				"reference_date": bank_transaction.date,
+				"posting_date": bank_transaction.date,
+			},
+		)
+
+		payment_entry = frappe.get_doc("Payment Entry", result["voucher_name"])
+		self.assertEqual(payment_entry.docstatus, 1)
+		self.assert_transaction_bank_account(payment_entry, "paid_to")


### PR DESCRIPTION
## Summary

- align Payment Entry Company Bank Account with the selected Bank Transaction
- pass the selected bank ledger into invoice-derived Payment Entry construction before currency and amount fields are derived
- populate bank name and account number for direct, draft, submitted, invoice, and bank-rule paths
- add Pay and Receive regression coverage with an unrelated default Bank Account

## Test plan

- focused Bank Account regression module: 5 passed
- reference fallback module: 3 passed
- partial allocation module: 70 passed, 2 skipped
- bulk precision module: 1 passed
- modern Bank Rec API module: 40 passed
- Bank Rule module: 81 passed
- Ruff checks and Python compilation passed

Total: 200 passed, 2 skipped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Payment entries now consistently use the bank account associated with the originating bank transaction.
  * Bank details, currencies, account types, and customer or supplier payment fields are populated correctly for invoice and direct payments.

* **Tests**
  * Added coverage for customer, supplier, invoice, direct, and submitted payment scenarios to verify accurate bank account information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->