### PR TITLE
fix: add configurable party company filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 tags
 node_modules
 __pycache__
+.worktrees/
 
 advanced_bank_reconciliation/public/dist
 advanced_bank_reconciliation/public/bank_rec

--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/abr_bank_rule/abr_bank_rule.js
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/abr_bank_rule/abr_bank_rule.js
@@ -21,6 +21,14 @@ frappe.ui.form.on("ABR Bank Rule", {
 			};
 		});
 
+		frm.set_query("party", () => ({
+			query: "advanced_bank_reconciliation.api.party_company.search_parties",
+			filters: {
+				party_type: frm.doc.party_type,
+				company: frm.doc.company,
+			},
+		}));
+
 		for (const field of ["account", "cost_center"]) {
 			frm.set_query(field, function () {
 				return {
@@ -35,8 +43,12 @@ frappe.ui.form.on("ABR Bank Rule", {
 	},
 
 	company(frm) {
-		for (const field of ["bank_account", "account", "cost_center"]) {
+		for (const field of ["bank_account", "account", "cost_center", "party"]) {
 			frm.set_value(field, "");
 		}
+	},
+
+	party_type(frm) {
+		frm.set_value("party", "");
 	},
 });

--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/abr_bank_rule/abr_bank_rule.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/abr_bank_rule/abr_bank_rule.py
@@ -7,6 +7,7 @@ import frappe
 from frappe.model.document import Document
 from frappe.utils import flt
 
+from advanced_bank_reconciliation.api.permission import assert_party_access
 from advanced_bank_reconciliation.advanced_bank_reconciliation.doctype.advance_bank_reconciliation_tool.advance_bank_reconciliation_tool import (
 	create_journal_entry_bts,
 	create_payment_entry_bts,
@@ -78,6 +79,11 @@ class ABRBankRule(Document):
 			if not self.party:
 				frappe.throw("Party is required for Payment Entry rules")
 
+		assert_party_access(
+			self.party_type,
+			self.party,
+			company=self.company,
+		)
 		self._validate_bank_account_company()
 		self._validate_conditions()
 
@@ -336,6 +342,11 @@ def _get_rule_dimensions(rule):
 def _execute_rule_action(transaction, rule, logger):
 	"""Create a JE or PE based on the rule's action configuration."""
 	dimensions = _get_rule_dimensions(rule)
+	assert_party_access(
+		rule.party_type,
+		rule.party,
+		company=transaction.company or rule.company,
+	)
 
 	if rule.entry_type == "Journal Entry":
 		create_journal_entry_bts(

--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/abr_bank_rule/test_abr_bank_rule.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/abr_bank_rule/test_abr_bank_rule.py
@@ -10,6 +10,7 @@ from frappe.utils import add_days, today
 
 from advanced_bank_reconciliation.advanced_bank_reconciliation.doctype.abr_bank_rule.abr_bank_rule import (
 	_conditions_match,
+	_execute_rule_action,
 	_load_rules,
 	_match_transaction,
 	evaluate_condition,
@@ -205,6 +206,25 @@ class TestABRBankRuleValidation(FrappeTestCase):
 		)
 		rule.insert()
 		self.assertTrue(rule.name)
+
+	def test_rule_party_is_validated_for_rule_company(self):
+		rule = self._make_rule(
+			entry_type="Payment Entry",
+			account="",
+			party_type="Customer",
+			party="_Test Customer",
+		)
+		with patch(
+			f"{ABR_MODULE}.assert_party_access",
+			side_effect=frappe.ValidationError,
+		) as assert_party:
+			with self.assertRaises(frappe.ValidationError):
+				rule.insert()
+		assert_party.assert_called_once_with(
+			"Customer",
+			"_Test Customer",
+			company=TEST_COMPANY,
+		)
 
 	def test_condition_without_value_fails(self):
 		with self.assertRaises(frappe.ValidationError):
@@ -632,6 +652,42 @@ class TestRulePriority(FrappeTestCase):
 # ============================================================================
 # Group 5: Integration - run_bank_rules (real txns + rules, mocked actions)
 # ============================================================================
+
+
+class TestExecuteRuleAction(FrappeTestCase):
+	def test_rule_execution_revalidates_party_company(self):
+		transaction = frappe._dict(
+			name="_Test Bank Transaction",
+			company=TEST_COMPANY,
+			reference_number="",
+			date=today(),
+		)
+		rule = frappe._dict(
+			name="ABR-RULE-TEST",
+			title="Runtime Validation Rule",
+			entry_type="Payment Entry",
+			company=TEST_COMPANY,
+			party_type="Customer",
+			party="_Test Customer",
+			cost_center=None,
+			project=None,
+		)
+		with (
+			patch(f"{ABR_MODULE}._get_rule_dimensions", return_value={}),
+			patch(
+				f"{ABR_MODULE}.assert_party_access",
+				side_effect=frappe.ValidationError("Not available"),
+			) as assert_party,
+			patch(f"{ABR_MODULE}.create_payment_entry_bts") as create_payment_entry,
+		):
+			with self.assertRaises(frappe.ValidationError):
+				_execute_rule_action(transaction, rule, get_test_logger())
+		assert_party.assert_called_once_with(
+			"Customer",
+			"_Test Customer",
+			company=TEST_COMPANY,
+		)
+		create_payment_entry.assert_not_called()
 
 
 class TestRunBankRules(FrappeTestCase):

--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_settings/advance_bank_reconciliation_settings.js
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_settings/advance_bank_reconciliation_settings.js
@@ -1,8 +1,25 @@
 // Copyright (c) 2025, HighFlyer and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Advance Bank Reconciliation Settings", {
-// 	refresh(frm) {
+const partyCompanyFields = {
+	customer_company_field: "Customer",
+	supplier_company_field: "Supplier",
+	employee_company_field: "Employee",
+};
 
-// 	},
-// });
+frappe.ui.form.on("Advance Bank Reconciliation Settings", {
+	async refresh(frm) {
+		for (const [fieldname, partyType] of Object.entries(partyCompanyFields)) {
+			const { message = [] } = await frappe.call({
+				method: "advanced_bank_reconciliation.api.party_company.get_company_link_fields",
+				args: { party_type: partyType },
+			});
+			frm.fields_dict[fieldname].set_data(
+				message.map((row) => ({
+					label: `${row.label} (${row.fieldname})`,
+					value: row.fieldname,
+				}))
+			);
+		}
+	},
+});

--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_settings/advance_bank_reconciliation_settings.json
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_settings/advance_bank_reconciliation_settings.json
@@ -12,6 +12,11 @@
   "default_journal_entry_type",
   "matching_dialog_section",
   "compact_matching_vouchers_table",
+  "party_company_filtering_section",
+  "filter_parties_by_company",
+  "customer_company_field",
+  "supplier_company_field",
+  "employee_company_field",
   "reconciling_unpaid_invoices_section",
   "sort_unpaid_invoices_by_posting_date",
   "validate_selection_against_unallocated_amount",
@@ -66,6 +71,43 @@
    "label": "Compact matching vouchers table"
   },
   {
+   "fieldname": "party_company_filtering_section",
+   "fieldtype": "Section Break",
+   "label": "Party Company Filtering"
+  },
+  {
+   "default": "0",
+   "description": "Restrict Customer, Supplier, and Employee selections to the reconciliation company while allowing records with a blank company as shared.",
+   "fieldname": "filter_parties_by_company",
+   "fieldtype": "Check",
+   "label": "Filter Parties by Company"
+  },
+  {
+   "depends_on": "eval:doc.filter_parties_by_company",
+   "description": "Link field on Customer that identifies the owning company.",
+   "fieldname": "customer_company_field",
+   "fieldtype": "Autocomplete",
+   "label": "Customer Company Field",
+   "mandatory_depends_on": "eval:doc.filter_parties_by_company"
+  },
+  {
+   "depends_on": "eval:doc.filter_parties_by_company",
+   "description": "Link field on Supplier that identifies the owning company.",
+   "fieldname": "supplier_company_field",
+   "fieldtype": "Autocomplete",
+   "label": "Supplier Company Field",
+   "mandatory_depends_on": "eval:doc.filter_parties_by_company"
+  },
+  {
+   "default": "company",
+   "depends_on": "eval:doc.filter_parties_by_company",
+   "description": "Link field on Employee that identifies the owning company.",
+   "fieldname": "employee_company_field",
+   "fieldtype": "Autocomplete",
+   "label": "Employee Company Field",
+   "mandatory_depends_on": "eval:doc.filter_parties_by_company"
+  },
+  {
    "fieldname": "reconciling_unpaid_invoices_section",
    "fieldtype": "Section Break",
    "label": "Reconciling Unpaid Invoices"
@@ -96,7 +138,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-04-28 13:00:00.000000",
+ "modified": "2026-07-25 09:38:24.000000",
  "modified_by": "Administrator",
  "module": "Advanced Bank Reconciliation",
  "name": "Advance Bank Reconciliation Settings",

--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_settings/advance_bank_reconciliation_settings.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_settings/advance_bank_reconciliation_settings.py
@@ -1,8 +1,12 @@
 # Copyright (c) 2025, HighFlyer and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
+
+from advanced_bank_reconciliation.api.party_company import (
+	validate_enabled_bank_rules,
+	validate_party_company_settings,
+)
 
 
 class AdvanceBankReconciliationSettings(Document):
@@ -14,7 +18,14 @@ class AdvanceBankReconciliationSettings(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
+		customer_company_field: DF.Autocomplete | None
+		employee_company_field: DF.Autocomplete | None
+		filter_parties_by_company: DF.Check
 		reconcile_unpaid_invoices_in_background: DF.Check
+		supplier_company_field: DF.Autocomplete | None
 		validate_selection_against_unallocated_amount: DF.Check
 	# end: auto-generated types
-	pass
+
+	def validate(self):
+		validate_party_company_settings(self)
+		validate_enabled_bank_rules(self)

--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_settings/test_advance_bank_reconciliation_settings.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_settings/test_advance_bank_reconciliation_settings.py
@@ -1,9 +1,145 @@
 # Copyright (c) 2025, HighFlyer and Contributors
 # See license.txt
 
-# import frappe
+from unittest.mock import patch
+
+import frappe
 from frappe.tests.utils import FrappeTestCase
+
+from advanced_bank_reconciliation.api.party_company import (
+	get_company_link_fields,
+	validate_enabled_bank_rules,
+	validate_party_company_settings,
+)
+
+
+def field(fieldname, fieldtype="Link", options="Company", label=None):
+	return frappe._dict(
+		fieldname=fieldname,
+		fieldtype=fieldtype,
+		options=options,
+		label=label or fieldname.replace("_", " ").title(),
+	)
 
 
 class TestAdvanceBankReconciliationSettings(FrappeTestCase):
-	pass
+	def test_disabled_settings_allow_blank_mappings(self):
+		settings = frappe._dict(filter_parties_by_company=0)
+		validate_party_company_settings(settings)
+
+	def test_enabled_settings_require_every_mapping(self):
+		settings = frappe._dict(
+			filter_parties_by_company=1,
+			customer_company_field="",
+			supplier_company_field="supplier_scope",
+			employee_company_field="company",
+		)
+		with self.assertRaisesRegex(
+			frappe.ValidationError,
+			"Configure the Customer Company Field",
+		):
+			validate_party_company_settings(settings)
+
+	def test_enabled_settings_accept_company_links(self):
+		settings = frappe._dict(
+			filter_parties_by_company=1,
+			customer_company_field="customer_scope",
+			supplier_company_field="supplier_scope",
+			employee_company_field="company",
+		)
+		metas = {
+			"Customer": frappe._dict(fields=[field("customer_scope")]),
+			"Supplier": frappe._dict(fields=[field("supplier_scope")]),
+			"Employee": frappe._dict(fields=[field("company")]),
+		}
+		for meta in metas.values():
+			meta.get_field = lambda fieldname, meta=meta: next(
+				(row for row in meta.fields if row.fieldname == fieldname),
+				None,
+			)
+		with patch("frappe.get_meta", side_effect=lambda doctype: metas[doctype]):
+			validate_party_company_settings(settings)
+
+	def test_non_company_link_mapping_is_rejected(self):
+		settings = frappe._dict(
+			filter_parties_by_company=1,
+			customer_company_field="customer_scope",
+			supplier_company_field="supplier_scope",
+			employee_company_field="company",
+		)
+		meta = frappe._dict(fields=[field("customer_scope", options="Customer Group")])
+		meta.get_field = lambda fieldname: next(
+			(row for row in meta.fields if row.fieldname == fieldname),
+			None,
+		)
+		with patch("frappe.get_meta", return_value=meta):
+			with self.assertRaisesRegex(
+				frappe.ValidationError,
+				"must be a Link to Company",
+			):
+				validate_party_company_settings(settings)
+
+	def test_candidate_fields_only_include_company_links(self):
+		meta = frappe._dict(
+			fields=[
+				field("company_scope", label="Company Scope"),
+				field("represents_company"),
+				field("territory", options="Territory"),
+				field("notes", fieldtype="Data", options=None),
+			]
+		)
+		with (
+			patch("frappe.has_permission", return_value=True),
+			patch("frappe.get_meta", return_value=meta),
+		):
+			self.assertEqual(
+				get_company_link_fields("Customer"),
+				[
+					{"fieldname": "company_scope", "label": "Company Scope"},
+					{"fieldname": "represents_company", "label": "Represents Company"},
+				],
+			)
+
+	def test_mapping_defaults_are_safe(self):
+		meta = frappe.get_meta("Advance Bank Reconciliation Settings")
+		self.assertEqual(meta.get_field("filter_parties_by_company").default, "0")
+		self.assertFalse(meta.get_field("customer_company_field").default)
+		self.assertFalse(meta.get_field("supplier_company_field").default)
+		self.assertEqual(meta.get_field("employee_company_field").default, "company")
+
+	def test_disabled_settings_skip_rule_validation(self):
+		settings = frappe._dict(filter_parties_by_company=0)
+		with patch("frappe.get_all") as get_all:
+			validate_enabled_bank_rules(settings)
+		get_all.assert_not_called()
+
+	def test_enabled_settings_reject_ineligible_rules_without_updating_them(self):
+		settings = frappe._dict(filter_parties_by_company=1)
+		rules = [
+			frappe._dict(
+				name="Rule One",
+				party_type="Customer",
+				party="_Test Customer",
+				company="_Test Company",
+			),
+			frappe._dict(
+				name="Rule Two",
+				party_type="Supplier",
+				party="_Test Supplier",
+				company="_Test Company",
+			),
+		]
+		with (
+			patch("frappe.get_all", return_value=rules),
+			patch(
+				"advanced_bank_reconciliation.api.party_company.is_party_eligible_for_company",
+				side_effect=[False, True],
+			),
+			patch("frappe.db.set_value") as set_value,
+		):
+			with self.assertRaisesRegex(
+				frappe.ValidationError,
+				"Rule One.*correct or disable",
+			):
+				validate_enabled_bank_rules(settings)
+		set_value.assert_not_called()

--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/advance_bank_reconciliation_tool.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/advance_bank_reconciliation_tool.py
@@ -3,6 +3,7 @@
 import json
 
 import frappe
+from advanced_bank_reconciliation.api.permission import assert_party_access
 from advanced_bank_reconciliation.utils.logger import get_logger
 from erpnext import get_default_cost_center
 from erpnext.accounts.doctype.bank_transaction.bank_transaction import (
@@ -327,6 +328,12 @@ def get_account_balance(bank_account, till_date):
 def update_bank_transaction(bank_transaction_name, reference_number, party_type=None, party=None):
 	# updates bank transaction based on the new parameters provided by the user from Vouchers
 	bank_transaction = frappe.get_doc("Bank Transaction", bank_transaction_name)
+	company = bank_transaction.company or frappe.get_cached_value(
+		"Bank Account",
+		bank_transaction.bank_account,
+		"company",
+	)
+	assert_party_access(party_type, party, company=company)
 	bank_transaction.reference_number = reference_number
 	bank_transaction.party_type = party_type
 	bank_transaction.party = party
@@ -415,7 +422,15 @@ def create_journal_entry_bts(
 	bank_transaction = frappe.db.get_values(
 		"Bank Transaction",
 		bank_transaction_name,
-		fieldname=["name", "deposit", "withdrawal", "bank_account", "currency", "unallocated_amount"],
+		fieldname=[
+			"name",
+			"deposit",
+			"withdrawal",
+			"bank_account",
+			"company",
+			"currency",
+			"unallocated_amount",
+		],
 		as_dict=True,
 	)[0]
 	company_account = frappe.get_value("Bank Account", bank_transaction.bank_account, "account")
@@ -428,7 +443,8 @@ def create_journal_entry_bts(
 				)
 			)
 
-	company = frappe.get_value("Account", company_account, "company")
+	company = bank_transaction.company or frappe.get_value("Account", company_account, "company")
+	assert_party_access(party_type, party, company=company)
 	resolved_cost_center = cost_center or get_default_cost_center(company)
 	company_default_currency = frappe.get_cached_value("Company", company, "default_currency")
 	company_account_currency = frappe.get_cached_value("Account", company_account, "account_currency")
@@ -611,14 +627,22 @@ def create_payment_entry_bts(
 	bank_transaction = frappe.db.get_values(
 		"Bank Transaction",
 		bank_transaction_name,
-		fieldname=["name", "unallocated_amount", "deposit", "bank_account", "currency"],
+		fieldname=[
+			"name",
+			"unallocated_amount",
+			"deposit",
+			"bank_account",
+			"company",
+			"currency",
+		],
 		as_dict=True,
 	)[0]
 
 	payment_type = "Receive" if bank_transaction.deposit > 0.0 else "Pay"
 
 	bank_account = frappe.get_cached_value("Bank Account", bank_transaction.bank_account, "account")
-	company = frappe.get_cached_value("Account", bank_account, "company")
+	company = bank_transaction.company or frappe.get_cached_value("Account", bank_account, "company")
+	assert_party_access(party_type, party, company=company)
 	party_account = get_party_account(party_type, party, company)
 
 	bank_currency = bank_transaction.currency

--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/advance_bank_reconciliation_tool.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/advance_bank_reconciliation_tool.py
@@ -3,7 +3,10 @@
 import json
 
 import frappe
-from advanced_bank_reconciliation.api.permission import assert_party_access
+from advanced_bank_reconciliation.api.permission import (
+	assert_company_access,
+	assert_party_access,
+)
 from advanced_bank_reconciliation.utils.logger import get_logger
 from erpnext import get_default_cost_center
 from erpnext.accounts.doctype.bank_transaction.bank_transaction import (
@@ -333,6 +336,7 @@ def update_bank_transaction(bank_transaction_name, reference_number, party_type=
 		bank_transaction.bank_account,
 		"company",
 	)
+	assert_company_access(company)
 	assert_party_access(party_type, party, company=company)
 	bank_transaction.reference_number = reference_number
 	bank_transaction.party_type = party_type
@@ -444,6 +448,7 @@ def create_journal_entry_bts(
 			)
 
 	company = bank_transaction.company or frappe.get_value("Account", company_account, "company")
+	assert_company_access(company)
 	assert_party_access(party_type, party, company=company)
 	resolved_cost_center = cost_center or get_default_cost_center(company)
 	company_default_currency = frappe.get_cached_value("Company", company, "default_currency")
@@ -642,6 +647,7 @@ def create_payment_entry_bts(
 
 	bank_account = frappe.get_cached_value("Bank Account", bank_transaction.bank_account, "account")
 	company = bank_transaction.company or frappe.get_cached_value("Account", bank_account, "company")
+	assert_company_access(company)
 	assert_party_access(party_type, party, company=company)
 	party_account = get_party_account(party_type, party, company)
 

--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/tests/test_party_company_enforcement.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/tests/test_party_company_enforcement.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
@@ -13,9 +13,46 @@ MODULE = (
 	"advanced_bank_reconciliation.advanced_bank_reconciliation.doctype."
 	"advance_bank_reconciliation_tool.advance_bank_reconciliation_tool"
 )
+LOCAL_UPDATE_METHOD = f"{MODULE}.update_bank_transaction"
+UPSTREAM_UPDATE_METHOD = (
+	"erpnext.accounts.doctype.bank_reconciliation_tool."
+	"bank_reconciliation_tool.update_bank_transaction"
+)
 
 
 class TestLegacyPartyCompanyEnforcement(FrappeTestCase):
+	def test_standard_rpc_update_resolves_to_guarded_local_method(self):
+		self.assertEqual(
+			frappe.override_whitelisted_method(UPSTREAM_UPDATE_METHOD),
+			LOCAL_UPDATE_METHOD,
+		)
+		rpc_method = frappe.get_attr(
+			frappe.override_whitelisted_method(UPSTREAM_UPDATE_METHOD)
+		)
+		transaction = frappe._dict(
+			name="_Test Bank Transaction",
+			company="_Test Company",
+			bank_account="_Test Bank Account",
+		)
+		transaction.save = Mock()
+
+		with (
+			patch(f"{MODULE}.frappe.get_doc", return_value=transaction),
+			patch(
+				f"{MODULE}.assert_party_access",
+				side_effect=frappe.ValidationError,
+			),
+		):
+			with self.assertRaises(frappe.ValidationError):
+				rpc_method(
+					transaction.name,
+					"REF",
+					"Customer",
+					"_Test Customer",
+				)
+
+		transaction.save.assert_not_called()
+
 	def test_update_validates_against_transaction_company(self):
 		transaction = frappe._dict(
 			name="_Test Bank Transaction",

--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/tests/test_party_company_enforcement.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/tests/test_party_company_enforcement.py
@@ -1,0 +1,99 @@
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from advanced_bank_reconciliation.advanced_bank_reconciliation.doctype.advance_bank_reconciliation_tool.advance_bank_reconciliation_tool import (
+	create_journal_entry_bts,
+	create_payment_entry_bts,
+	update_bank_transaction,
+)
+
+MODULE = (
+	"advanced_bank_reconciliation.advanced_bank_reconciliation.doctype."
+	"advance_bank_reconciliation_tool.advance_bank_reconciliation_tool"
+)
+
+
+class TestLegacyPartyCompanyEnforcement(FrappeTestCase):
+	def test_update_validates_against_transaction_company(self):
+		transaction = frappe._dict(
+			name="_Test Bank Transaction",
+			company="_Test Company",
+			reference_number="",
+			party_type="",
+			party="",
+		)
+		transaction.save = lambda: None
+		with (
+			patch(f"{MODULE}.frappe.get_doc", return_value=transaction),
+			patch(f"{MODULE}.assert_party_access") as assert_party,
+			patch(f"{MODULE}.frappe.db.get_all", return_value=[transaction]),
+		):
+			update_bank_transaction(
+				transaction.name,
+				"REF",
+				"Customer",
+				"_Test Customer",
+			)
+		assert_party.assert_called_once_with(
+			"Customer",
+			"_Test Customer",
+			company="_Test Company",
+		)
+
+	def test_journal_entry_rejects_before_new_document(self):
+		with (
+			patch(
+				f"{MODULE}.frappe.db.get_values",
+				return_value=[
+					frappe._dict(
+						name="_Test Bank Transaction",
+						deposit=10,
+						withdrawal=0,
+						bank_account="_Test Bank Account",
+						currency="NZD",
+						unallocated_amount=10,
+					)
+				],
+			),
+			patch(f"{MODULE}.frappe.get_value", side_effect=["Bank - TC", "_Test Company"]),
+			patch(f"{MODULE}.frappe.db.get_value", return_value="Income"),
+			patch(f"{MODULE}.assert_party_access", side_effect=frappe.ValidationError),
+			patch(f"{MODULE}.frappe.new_doc") as new_doc,
+		):
+			with self.assertRaises(frappe.ValidationError):
+				create_journal_entry_bts(
+					"_Test Bank Transaction",
+					entry_type="Bank Entry",
+					second_account="Income - TC",
+					party_type="Customer",
+					party="_Test Customer",
+				)
+		new_doc.assert_not_called()
+
+	def test_payment_entry_rejects_before_party_account_lookup(self):
+		with (
+			patch(
+				f"{MODULE}.frappe.db.get_values",
+				return_value=[
+					frappe._dict(
+						name="_Test Bank Transaction",
+						deposit=10,
+						bank_account="_Test Bank Account",
+						currency="NZD",
+						unallocated_amount=10,
+					)
+				],
+			),
+			patch(f"{MODULE}.frappe.get_cached_value", side_effect=["Bank - TC", "_Test Company"]),
+			patch(f"{MODULE}.assert_party_access", side_effect=frappe.ValidationError),
+			patch("erpnext.accounts.party.get_party_account") as get_party_account,
+		):
+			with self.assertRaises(frappe.ValidationError):
+				create_payment_entry_bts(
+					"_Test Bank Transaction",
+					party_type="Supplier",
+					party="_Test Supplier",
+				)
+		get_party_account.assert_not_called()

--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/tests/test_party_company_enforcement.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/tests/test_party_company_enforcement.py
@@ -38,6 +38,7 @@ class TestLegacyPartyCompanyEnforcement(FrappeTestCase):
 
 		with (
 			patch(f"{MODULE}.frappe.get_doc", return_value=transaction),
+			patch(f"{MODULE}.assert_company_access"),
 			patch(
 				f"{MODULE}.assert_party_access",
 				side_effect=frappe.ValidationError,
@@ -53,6 +54,28 @@ class TestLegacyPartyCompanyEnforcement(FrappeTestCase):
 
 		transaction.save.assert_not_called()
 
+	def test_update_rejects_company_before_save_when_party_is_blank(self):
+		transaction = frappe._dict(
+			name="_Test Bank Transaction",
+			company="_Test Company",
+			bank_account="_Test Bank Account",
+		)
+		transaction.save = Mock()
+
+		with (
+			patch(f"{MODULE}.frappe.get_doc", return_value=transaction),
+			patch(
+				f"{MODULE}.assert_company_access",
+				side_effect=frappe.PermissionError,
+			),
+			patch(f"{MODULE}.assert_party_access") as assert_party,
+		):
+			with self.assertRaises(frappe.PermissionError):
+				update_bank_transaction(transaction.name, "REF")
+
+		assert_party.assert_not_called()
+		transaction.save.assert_not_called()
+
 	def test_update_validates_against_transaction_company(self):
 		transaction = frappe._dict(
 			name="_Test Bank Transaction",
@@ -64,6 +87,7 @@ class TestLegacyPartyCompanyEnforcement(FrappeTestCase):
 		transaction.save = lambda: None
 		with (
 			patch(f"{MODULE}.frappe.get_doc", return_value=transaction),
+			patch(f"{MODULE}.assert_company_access") as assert_company,
 			patch(f"{MODULE}.assert_party_access") as assert_party,
 			patch(f"{MODULE}.frappe.db.get_all", return_value=[transaction]),
 		):
@@ -73,6 +97,7 @@ class TestLegacyPartyCompanyEnforcement(FrappeTestCase):
 				"Customer",
 				"_Test Customer",
 			)
+		assert_company.assert_called_once_with("_Test Company")
 		assert_party.assert_called_once_with(
 			"Customer",
 			"_Test Customer",
@@ -96,6 +121,7 @@ class TestLegacyPartyCompanyEnforcement(FrappeTestCase):
 			),
 			patch(f"{MODULE}.frappe.get_value", side_effect=["Bank - TC", "_Test Company"]),
 			patch(f"{MODULE}.frappe.db.get_value", return_value="Income"),
+			patch(f"{MODULE}.assert_company_access"),
 			patch(f"{MODULE}.assert_party_access", side_effect=frappe.ValidationError),
 			patch(f"{MODULE}.frappe.new_doc") as new_doc,
 		):
@@ -107,6 +133,41 @@ class TestLegacyPartyCompanyEnforcement(FrappeTestCase):
 					party_type="Customer",
 					party="_Test Customer",
 				)
+		new_doc.assert_not_called()
+
+	def test_journal_entry_rejects_company_before_party_validation(self):
+		with (
+			patch(
+				f"{MODULE}.frappe.db.get_values",
+				return_value=[
+					frappe._dict(
+						name="_Test Bank Transaction",
+						deposit=10,
+						withdrawal=0,
+						bank_account="_Test Bank Account",
+						company="_Test Company",
+						currency="NZD",
+						unallocated_amount=10,
+					)
+				],
+			),
+			patch(f"{MODULE}.frappe.get_value", return_value="Bank - TC"),
+			patch(f"{MODULE}.frappe.db.get_value", return_value="Income"),
+			patch(
+				f"{MODULE}.assert_company_access",
+				side_effect=frappe.PermissionError,
+			),
+			patch(f"{MODULE}.assert_party_access") as assert_party,
+			patch(f"{MODULE}.frappe.new_doc") as new_doc,
+		):
+			with self.assertRaises(frappe.PermissionError):
+				create_journal_entry_bts(
+					"_Test Bank Transaction",
+					entry_type="Bank Entry",
+					second_account="Income - TC",
+				)
+
+		assert_party.assert_not_called()
 		new_doc.assert_not_called()
 
 	def test_payment_entry_rejects_before_party_account_lookup(self):
@@ -124,6 +185,7 @@ class TestLegacyPartyCompanyEnforcement(FrappeTestCase):
 				],
 			),
 			patch(f"{MODULE}.frappe.get_cached_value", side_effect=["Bank - TC", "_Test Company"]),
+			patch(f"{MODULE}.assert_company_access"),
 			patch(f"{MODULE}.assert_party_access", side_effect=frappe.ValidationError),
 			patch("erpnext.accounts.party.get_party_account") as get_party_account,
 		):
@@ -133,4 +195,33 @@ class TestLegacyPartyCompanyEnforcement(FrappeTestCase):
 					party_type="Supplier",
 					party="_Test Supplier",
 				)
+		get_party_account.assert_not_called()
+
+	def test_payment_entry_rejects_company_before_party_account_lookup(self):
+		with (
+			patch(
+				f"{MODULE}.frappe.db.get_values",
+				return_value=[
+					frappe._dict(
+						name="_Test Bank Transaction",
+						deposit=10,
+						bank_account="_Test Bank Account",
+						company="_Test Company",
+						currency="NZD",
+						unallocated_amount=10,
+					)
+				],
+			),
+			patch(f"{MODULE}.frappe.get_cached_value", return_value="Bank - TC"),
+			patch(
+				f"{MODULE}.assert_company_access",
+				side_effect=frappe.PermissionError,
+			),
+			patch(f"{MODULE}.assert_party_access") as assert_party,
+			patch("erpnext.accounts.party.get_party_account") as get_party_account,
+		):
+			with self.assertRaises(frappe.PermissionError):
+				create_payment_entry_bts("_Test Bank Transaction")
+
+		assert_party.assert_not_called()
 		get_party_account.assert_not_called()

--- a/advanced_bank_reconciliation/api/cash_coding.py
+++ b/advanced_bank_reconciliation/api/cash_coding.py
@@ -158,7 +158,11 @@ def preview_cash_coding(rows):
 				"company",
 			)
 			assert_company_access(company)
-			assert_party_access(row.get("party_type"), row.get("party"))
+			assert_party_access(
+				row.get("party_type"),
+				row.get("party"),
+				company=company,
+			)
 			account = _assert_account(row.get("account"), company)
 			if account.account_type in ["Receivable", "Payable"] and (
 				not row.get("party_type") or not row.get("party")
@@ -207,7 +211,11 @@ def submit_cash_coding(rows):
 				"company",
 			)
 			assert_company_access(company)
-			assert_party_access(row.get("party_type"), row.get("party"))
+			assert_party_access(
+				row.get("party_type"),
+				row.get("party"),
+				company=company,
+			)
 			account = _assert_account(row.get("account"), company)
 			if account.account_type in ["Receivable", "Payable"] and (
 				not row.get("party_type") or not row.get("party")

--- a/advanced_bank_reconciliation/api/create_voucher.py
+++ b/advanced_bank_reconciliation/api/create_voucher.py
@@ -94,7 +94,11 @@ def _build_voucher(transaction, payload, allow_edit=False):
 	company = _get_company(transaction)
 	entry_type = _selected_entry_type(payload)
 	common = _common_kwargs(transaction, payload)
-	assert_party_access(common["party_type"], common["party"])
+	assert_party_access(
+		common["party_type"],
+		common["party"],
+		company=company,
+	)
 
 	if entry_type == "Payment Entry":
 		if not common["party_type"] or not common["party"]:

--- a/advanced_bank_reconciliation/api/matching.py
+++ b/advanced_bank_reconciliation/api/matching.py
@@ -277,7 +277,12 @@ def update_transaction_metadata(
 	_lock_bank_transaction(transaction.name)
 	transaction.reload()
 
-	assert_party_access(party_type, party)
+	company = transaction.company or frappe.get_cached_value(
+		"Bank Account",
+		transaction.bank_account,
+		"company",
+	)
+	assert_party_access(party_type, party, company=company)
 
 	transaction.reference_number = reference_number or ""
 	transaction.party_type = party_type or ""

--- a/advanced_bank_reconciliation/api/party_company.py
+++ b/advanced_bank_reconciliation/api/party_company.py
@@ -156,6 +156,7 @@ def _has_check_field(meta, fieldname):
 
 
 @frappe.whitelist()
+@frappe.validate_and_sanitize_search_inputs
 def search_parties(
 	doctype,
 	txt,
@@ -164,6 +165,7 @@ def search_parties(
 	page_len,
 	filters,
 	exact_party=None,
+	reference_doctype=None,
 ):
 	filters = frappe.parse_json(filters) if isinstance(filters, str) else (filters or {})
 	if not isinstance(filters, dict):
@@ -211,6 +213,7 @@ def search_parties(
 		limit_start=int(start),
 		limit_page_length=int(page_len),
 		as_list=True,
+		reference_doctype=reference_doctype,
 	)
 
 

--- a/advanced_bank_reconciliation/api/party_company.py
+++ b/advanced_bank_reconciliation/api/party_company.py
@@ -1,0 +1,253 @@
+import frappe
+from frappe import _
+
+
+SUPPORTED_PARTY_TYPES: tuple[str, ...] = ("Customer", "Supplier", "Employee")
+PARTY_COMPANY_SETTING_FIELDS: dict[str, str] = {
+	"Customer": "customer_company_field",
+	"Supplier": "supplier_company_field",
+	"Employee": "employee_company_field",
+}
+
+TEXT_FIELD_TYPES = {
+	"Data",
+	"Text",
+	"Small Text",
+	"Long Text",
+	"Link",
+	"Select",
+	"Read Only",
+	"Text Editor",
+}
+
+
+def _get_settings(settings=None):
+	return settings or frappe.get_cached_doc("Advance Bank Reconciliation Settings")
+
+
+def _require_supported_party_type(party_type):
+	if party_type not in SUPPORTED_PARTY_TYPES:
+		frappe.throw(
+			_("Party Type {0} is not supported in Bank Rec.").format(party_type)
+		)
+
+
+def _validate_company_link_field(party_type, fieldname):
+	field = frappe.get_meta(party_type).get_field(fieldname)
+	if not field or field.fieldtype != "Link" or field.options != "Company":
+		frappe.throw(
+			_("Field {0} on {1} must be a Link to Company.").format(
+				fieldname,
+				party_type,
+			)
+		)
+	return field
+
+
+@frappe.whitelist()
+def get_company_link_fields(party_type: str) -> list[dict[str, str]]:
+	frappe.has_permission(
+		"Advance Bank Reconciliation Settings",
+		"read",
+		throw=True,
+	)
+	_require_supported_party_type(party_type)
+
+	return [
+		{"fieldname": field.fieldname, "label": field.label}
+		for field in frappe.get_meta(party_type).fields
+		if field.fieldtype == "Link" and field.options == "Company"
+	]
+
+
+def get_party_company_field(party_type: str, settings=None) -> str | None:
+	settings = _get_settings(settings)
+	if not settings.get("filter_parties_by_company"):
+		return None
+
+	_require_supported_party_type(party_type)
+	settings_field = PARTY_COMPANY_SETTING_FIELDS[party_type]
+	fieldname = settings.get(settings_field)
+	if not fieldname:
+		frappe.throw(
+			_("Configure the {0} Company Field in Advance Bank Reconciliation Settings.").format(
+				party_type
+			)
+		)
+
+	_validate_company_link_field(party_type, fieldname)
+	return fieldname
+
+
+def is_party_eligible_for_company(
+	party_type: str,
+	party: str,
+	company: str,
+	settings=None,
+) -> bool:
+	fieldname = get_party_company_field(party_type, settings=settings)
+	if not fieldname:
+		return True
+
+	party_company = frappe.get_cached_value(party_type, party, fieldname)
+	return not party_company or party_company == company
+
+
+def assert_party_eligible_for_company(
+	party_type: str,
+	party: str,
+	company: str,
+	user: str | None = None,
+	settings=None,
+):
+	_require_supported_party_type(party_type)
+	if not party:
+		frappe.throw(_("Party is required when Party Type is set."))
+
+	user = user or frappe.session.user
+	doc = frappe.get_doc(party_type, party)
+	frappe.has_permission(party_type, "read", doc=doc, user=user, throw=True)
+
+	fieldname = get_party_company_field(party_type, settings=settings)
+	if not fieldname:
+		return doc
+	if not company:
+		frappe.throw(_("Company is required when party company filtering is enabled."))
+
+	party_company = frappe.get_cached_value(party_type, party, fieldname)
+	if not party_company or party_company == company:
+		return doc
+
+	frappe.throw(
+		_("{0} {1} is not available for company {2}.").format(
+			party_type,
+			party,
+			company,
+		)
+	)
+
+
+def _get_search_fields(meta, searchfield):
+	candidates = ["name"]
+	if meta.title_field:
+		candidates.append(meta.title_field)
+	if meta.search_fields:
+		candidates.extend(meta.get_search_fields())
+	if searchfield:
+		candidates.append(searchfield)
+
+	fields = []
+	for fieldname in candidates:
+		fieldname = fieldname.strip()
+		field = meta.get_field(fieldname)
+		if fieldname == "name" or (
+			not meta.translated_doctype
+			and field
+			and field.fieldtype in TEXT_FIELD_TYPES
+		):
+			if fieldname not in fields:
+				fields.append(fieldname)
+	return fields
+
+
+def _has_check_field(meta, fieldname):
+	field = meta.get_field(fieldname)
+	return bool(field and field.fieldtype == "Check")
+
+
+@frappe.whitelist()
+def search_parties(doctype, txt, searchfield, start, page_len, filters):
+	filters = frappe.parse_json(filters) if isinstance(filters, str) else (filters or {})
+	if not isinstance(filters, dict):
+		frappe.throw(_("Party search filters must be a dictionary."))
+
+	party_type = filters.get("party_type") or doctype
+	_require_supported_party_type(party_type)
+	if doctype != party_type:
+		frappe.throw(
+			_("Party Type {0} does not match {1}.").format(party_type, doctype)
+		)
+
+	company = filters.get("company")
+	mapped_field = get_party_company_field(party_type)
+	if mapped_field and not company:
+		frappe.throw(_("Company is required when party company filtering is enabled."))
+
+	from advanced_bank_reconciliation.api.permission import assert_company_access
+
+	company = assert_company_access(company)
+	meta = frappe.get_meta(doctype)
+	fields = _get_search_fields(meta, searchfield)
+	query_filters = []
+	if _has_check_field(meta, "enabled"):
+		query_filters.append([doctype, "enabled", "=", 1])
+	if _has_check_field(meta, "disabled"):
+		query_filters.append([doctype, "disabled", "!=", 1])
+	if mapped_field:
+		query_filters.append([doctype, mapped_field, "in", [company, ""]])
+
+	or_filters = []
+	if txt:
+		or_filters = [
+			[doctype, fieldname, "like", f"%{txt}%"]
+			for fieldname in fields
+		]
+
+	return frappe.get_list(
+		doctype,
+		fields=fields,
+		filters=query_filters,
+		or_filters=or_filters,
+		limit_start=int(start),
+		limit_page_length=int(page_len),
+		as_list=True,
+	)
+
+
+def validate_party_company_settings(settings) -> None:
+	if not settings.get("filter_parties_by_company"):
+		return
+
+	for party_type in SUPPORTED_PARTY_TYPES:
+		get_party_company_field(party_type, settings=settings)
+
+
+def validate_enabled_bank_rules(settings, limit: int = 20) -> None:
+	if not settings.get("filter_parties_by_company"):
+		return
+
+	rules = frappe.get_all(
+		"ABR Bank Rule",
+		filters={
+			"enabled": 1,
+			"party_type": ["is", "set"],
+			"party": ["is", "set"],
+		},
+		fields=["name", "party_type", "party", "company"],
+		order_by="name",
+	)
+	ineligible_rules = [
+		rule.name
+		for rule in rules
+		if not is_party_eligible_for_company(
+			rule.party_type,
+			rule.party,
+			rule.company,
+			settings=settings,
+		)
+	]
+	if not ineligible_rules:
+		return
+
+	shown_rules = ineligible_rules[:limit]
+	overflow = len(ineligible_rules) - len(shown_rules)
+	rule_list = ", ".join(shown_rules)
+	if overflow:
+		rule_list = _("{0}, and {1} more").format(rule_list, overflow)
+
+	frappe.throw(
+		_(
+			"These enabled bank rules use parties that are not available for their companies: "
+			"{0}. Please correct or disable those rules."
+		).format(rule_list)
+	)

--- a/advanced_bank_reconciliation/api/party_company.py
+++ b/advanced_bank_reconciliation/api/party_company.py
@@ -156,7 +156,15 @@ def _has_check_field(meta, fieldname):
 
 
 @frappe.whitelist()
-def search_parties(doctype, txt, searchfield, start, page_len, filters):
+def search_parties(
+	doctype,
+	txt,
+	searchfield,
+	start,
+	page_len,
+	filters,
+	exact_party=None,
+):
 	filters = frappe.parse_json(filters) if isinstance(filters, str) else (filters or {})
 	if not isinstance(filters, dict):
 		frappe.throw(_("Party search filters must be a dictionary."))
@@ -185,6 +193,8 @@ def search_parties(doctype, txt, searchfield, start, page_len, filters):
 		query_filters.append([doctype, "disabled", "!=", 1])
 	if mapped_field:
 		query_filters.append([doctype, mapped_field, "in", [company, ""]])
+	if exact_party:
+		query_filters.append([doctype, "name", "=", exact_party])
 
 	or_filters = []
 	if txt:

--- a/advanced_bank_reconciliation/api/permission.py
+++ b/advanced_bank_reconciliation/api/permission.py
@@ -1,6 +1,11 @@
 import frappe
 from frappe import _
 
+from advanced_bank_reconciliation.api.party_company import (
+	SUPPORTED_PARTY_TYPES,
+	assert_party_eligible_for_company,
+)
+
 
 ALLOWED_BANK_REC_ROLES = frozenset(
 	{
@@ -19,7 +24,7 @@ ALLOWED_VOUCHER_DOCTYPES = frozenset(
 	}
 )
 
-ALLOWED_PARTY_TYPES = frozenset({"Customer", "Supplier", "Employee"})
+ALLOWED_PARTY_TYPES = SUPPORTED_PARTY_TYPES
 
 
 def has_bank_rec_permission(user=None):
@@ -84,7 +89,7 @@ def assert_company_access(company, user=None):
 	return company
 
 
-def assert_party_access(party_type=None, party=None, user=None):
+def assert_party_access(party_type=None, party=None, company=None, user=None):
 	user = user or frappe.session.user
 	require_bank_rec_permission(user)
 
@@ -95,9 +100,12 @@ def assert_party_access(party_type=None, party=None, user=None):
 	if party_type and not party:
 		frappe.throw(_("Party is required when Party Type is set."))
 	if party_type and party:
-		doc = frappe.get_doc(party_type, party)
-		frappe.has_permission(party_type, "read", doc=doc, user=user, throw=True)
-		return doc
+		return assert_party_eligible_for_company(
+			party_type,
+			party,
+			company,
+			user=user,
+		)
 
 	return None
 

--- a/advanced_bank_reconciliation/api/test_bank_rec.py
+++ b/advanced_bank_reconciliation/api/test_bank_rec.py
@@ -18,6 +18,7 @@ from advanced_bank_reconciliation.api.matching import (
 	update_transaction_metadata,
 )
 from advanced_bank_reconciliation.api.create_voucher import (
+	_build_voucher,
 	create_voucher_draft_from_transaction,
 	create_voucher_from_transaction,
 	get_create_defaults,
@@ -444,6 +445,37 @@ class TestBankRecPhaseTwoAPI(FrappeTestCase):
 		self.assertEqual(bank_transaction.party_type, "Customer")
 		self.assertEqual(bank_transaction.party, TEST_CUSTOMER)
 
+	def test_update_metadata_passes_transaction_company_to_party_policy(self):
+		transaction = frappe._dict(
+			name="_Test Bank Transaction",
+			company="_Test Company",
+			status="Unreconciled",
+			reference_number="",
+			party_type="",
+			party="",
+		)
+		transaction.reload = lambda: None
+		transaction.save = lambda: None
+		transaction.as_dict = lambda: transaction
+		with (
+			patch(
+				"advanced_bank_reconciliation.api.matching.assert_bank_transaction_access",
+				return_value=transaction,
+			),
+			patch("advanced_bank_reconciliation.api.matching._lock_bank_transaction"),
+			patch("advanced_bank_reconciliation.api.matching.assert_party_access") as assert_party,
+		):
+			update_transaction_metadata(
+				transaction.name,
+				party_type="Customer",
+				party="_Test Customer",
+			)
+		assert_party.assert_called_once_with(
+			"Customer",
+			"_Test Customer",
+			company="_Test Company",
+		)
+
 
 class TestBankRecMutationGuardsAPI(FrappeTestCase):
 	@classmethod
@@ -596,6 +628,29 @@ class TestBankRecPhaseThreeAPI(FrappeTestCase):
 		self.assertEqual(result["transaction"]["name"], bank_transaction.name)
 		self.assertTrue(result["options"]["accounts"])
 		self.assertIn("posting_date", result["defaults"])
+
+	def test_create_voucher_passes_resolved_company_to_party_policy(self):
+		transaction = frappe._dict(name="_Test Bank Transaction")
+		payload = {"party_type": "Customer", "party": "_Test Customer"}
+		with (
+			patch(
+				"advanced_bank_reconciliation.api.create_voucher._get_company",
+				return_value="_Test Company",
+			),
+			patch(
+				"advanced_bank_reconciliation.api.create_voucher.assert_party_access"
+			) as assert_party,
+			patch(
+				"advanced_bank_reconciliation.api.create_voucher.create_payment_entry_bts",
+				return_value=frappe._dict(),
+			),
+		):
+			_build_voucher(transaction, payload, allow_edit=True)
+		assert_party.assert_called_once_with(
+			"Customer",
+			"_Test Customer",
+			company="_Test Company",
+		)
 
 	def test_create_defaults_include_accounting_dimensions(self):
 		bank_transaction = create_test_bank_transaction(
@@ -817,6 +872,82 @@ class TestBankRecPhaseFourAPI(FrappeTestCase):
 		)
 		self.assertTrue(account, "Expected a ledger account for {0}".format(root_type))
 		return account
+
+	def _cash_coding_row(self):
+		return {
+			"bank_transaction_name": "_Test Bank Transaction",
+			"party_type": "Customer",
+			"party": "_Test Customer",
+			"account": "Income - TC",
+		}
+
+	def _cash_coding_transaction(self):
+		transaction = frappe._dict(
+			name="_Test Bank Transaction",
+			company="_Test Company",
+			bank_account="_Test Bank Account",
+			status="Unreconciled",
+			unallocated_amount=10,
+		)
+		transaction.reload = lambda: None
+		return transaction
+
+	def test_cash_coding_preview_passes_company_to_party_policy(self):
+		row = self._cash_coding_row()
+		transaction = self._cash_coding_transaction()
+		with (
+			patch(
+				"advanced_bank_reconciliation.api.cash_coding.assert_bank_transaction_access",
+				return_value=transaction,
+			),
+			patch("advanced_bank_reconciliation.api.cash_coding.assert_company_access"),
+			patch(
+				"advanced_bank_reconciliation.api.cash_coding.assert_party_access",
+				side_effect=frappe.ValidationError("Not available"),
+			) as assert_party,
+			patch("advanced_bank_reconciliation.api.cash_coding._assert_account") as assert_account,
+		):
+			result = preview_cash_coding([row])
+		self.assertEqual(result["results"][0]["status"], "error")
+		assert_party.assert_called_once_with(
+			"Customer",
+			"_Test Customer",
+			company="_Test Company",
+		)
+		assert_account.assert_not_called()
+
+	def test_cash_coding_submit_rejects_before_journal_entry(self):
+		row = self._cash_coding_row()
+		transaction = self._cash_coding_transaction()
+		with (
+			patch(
+				"advanced_bank_reconciliation.api.cash_coding.assert_bank_transaction_access",
+				return_value=transaction,
+			),
+			patch("advanced_bank_reconciliation.api.cash_coding._lock_bank_transaction"),
+			patch("advanced_bank_reconciliation.api.cash_coding.assert_company_access"),
+			patch(
+				"advanced_bank_reconciliation.api.cash_coding.assert_party_access",
+				side_effect=frappe.ValidationError("Not available"),
+			) as assert_party,
+			patch(
+				"advanced_bank_reconciliation.api.cash_coding.create_journal_entry_bts"
+			) as create_journal_entry,
+			patch(
+				"advanced_bank_reconciliation.api.cash_coding.get_abr_default_settings",
+				return_value={"default_journal_entry_type": "Bank Entry"},
+			),
+			patch("advanced_bank_reconciliation.api.cash_coding.frappe.db.savepoint"),
+			patch("advanced_bank_reconciliation.api.cash_coding.frappe.db.rollback"),
+		):
+			result = submit_cash_coding([row])
+		self.assertEqual(result["results"][0]["status"], "error")
+		assert_party.assert_called_once_with(
+			"Customer",
+			"_Test Customer",
+			company="_Test Company",
+		)
+		create_journal_entry.assert_not_called()
 
 	def test_cash_coding_rows_include_unreconciled_transactions(self):
 		bank_transaction = create_test_bank_transaction(

--- a/advanced_bank_reconciliation/api/test_party_company.py
+++ b/advanced_bank_reconciliation/api/test_party_company.py
@@ -9,6 +9,7 @@ from advanced_bank_reconciliation.api.party_company import (
 	is_party_eligible_for_company,
 	search_parties,
 )
+from advanced_bank_reconciliation.api.permission import assert_party_access
 
 
 def enabled_settings():
@@ -236,3 +237,26 @@ class TestPartyCompanyPolicy(FrappeTestCase):
 						),
 						fieldname,
 					)
+
+
+class TestPartyCompanyPermissionIntegration(FrappeTestCase):
+	def test_assert_party_access_delegates_company_policy(self):
+		doc = frappe._dict(name="_Test Customer")
+		with patch(
+			"advanced_bank_reconciliation.api.permission.assert_party_eligible_for_company",
+			return_value=doc,
+		) as assert_eligible:
+			self.assertIs(
+				assert_party_access(
+					"Customer",
+					"_Test Customer",
+					company="_Test Company",
+				),
+				doc,
+			)
+		assert_eligible.assert_called_once_with(
+			"Customer",
+			"_Test Customer",
+			"_Test Company",
+			user=frappe.session.user,
+		)

--- a/advanced_bank_reconciliation/api/test_party_company.py
+++ b/advanced_bank_reconciliation/api/test_party_company.py
@@ -196,6 +196,51 @@ class TestPartyCompanyPolicy(FrappeTestCase):
 			get_list.call_args.kwargs["filters"],
 		)
 
+	def test_search_forwards_reference_doctype_without_bypassing_permissions(self):
+		meta = frappe._dict(
+			title_field="customer_name",
+			search_fields="customer_name",
+			translated_doctype=False,
+			fields=[],
+		)
+		meta.get_search_fields = Mock(return_value=["customer_name"])
+		meta.get_field = Mock(
+			side_effect=lambda name: frappe._dict(
+				fieldname=name,
+				fieldtype="Data",
+			)
+		)
+		with (
+			patch("frappe.get_meta", return_value=meta),
+			patch("frappe.get_list", return_value=[]) as get_list,
+			patch(
+				"advanced_bank_reconciliation.api.party_company.get_party_company_field",
+				return_value="company_scope",
+			),
+			patch(
+				"advanced_bank_reconciliation.api.permission.assert_company_access",
+				return_value="_Test Company",
+			),
+			patch("frappe.db.exists", return_value=True),
+		):
+			frappe.call(
+				search_parties,
+				doctype="Customer",
+				txt="",
+				searchfield="name",
+				start=0,
+				page_len=20,
+				filters={"company": "_Test Company", "party_type": "Customer"},
+				reference_doctype="ABR Bank Rule",
+				ignore_user_permissions=True,
+			)
+
+		self.assertEqual(
+			get_list.call_args.kwargs["reference_doctype"],
+			"ABR Bank Rule",
+		)
+		self.assertNotIn("ignore_user_permissions", get_list.call_args.kwargs)
+
 	def test_search_rejects_unsupported_party_type(self):
 		with patch("frappe.db.exists", return_value=True):
 			with self.assertRaisesRegex(

--- a/advanced_bank_reconciliation/api/test_party_company.py
+++ b/advanced_bank_reconciliation/api/test_party_company.py
@@ -155,6 +155,47 @@ class TestPartyCompanyPolicy(FrappeTestCase):
 			get_list.call_args.kwargs["filters"],
 		)
 
+	def test_exact_search_adds_party_name_filter(self):
+		meta = frappe._dict(
+			title_field="customer_name",
+			search_fields="customer_name",
+			translated_doctype=False,
+			fields=[],
+		)
+		meta.get_search_fields = Mock(return_value=["customer_name"])
+		meta.get_field = Mock(
+			side_effect=lambda name: frappe._dict(
+				fieldname=name,
+				fieldtype="Data",
+			)
+		)
+		with (
+			patch("frappe.get_meta", return_value=meta),
+			patch("frappe.get_list", return_value=[["_Test Customer"]]) as get_list,
+			patch(
+				"advanced_bank_reconciliation.api.party_company.get_party_company_field",
+				return_value="company_scope",
+			),
+			patch(
+				"advanced_bank_reconciliation.api.permission.assert_company_access",
+				return_value="_Test Company",
+			),
+			patch("frappe.db.exists", return_value=True),
+		):
+			search_parties(
+				"Customer",
+				"_Test Customer",
+				"name",
+				0,
+				20,
+				{"company": "_Test Company", "party_type": "Customer"},
+				exact_party="_Test Customer",
+			)
+		self.assertIn(
+			["Customer", "name", "=", "_Test Customer"],
+			get_list.call_args.kwargs["filters"],
+		)
+
 	def test_search_rejects_unsupported_party_type(self):
 		with patch("frappe.db.exists", return_value=True):
 			with self.assertRaisesRegex(

--- a/advanced_bank_reconciliation/api/test_party_company.py
+++ b/advanced_bank_reconciliation/api/test_party_company.py
@@ -1,0 +1,238 @@
+from unittest.mock import Mock, patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from advanced_bank_reconciliation.api.party_company import (
+	assert_party_eligible_for_company,
+	get_party_company_field,
+	is_party_eligible_for_company,
+	search_parties,
+)
+
+
+def enabled_settings():
+	return frappe._dict(
+		filter_parties_by_company=1,
+		customer_company_field="company_scope",
+		supplier_company_field="company_scope",
+		employee_company_field="company",
+	)
+
+
+class TestPartyCompanyPolicy(FrappeTestCase):
+	def test_disabled_policy_returns_no_mapping(self):
+		settings = frappe._dict(filter_parties_by_company=0)
+		self.assertIsNone(get_party_company_field("Customer", settings=settings))
+
+	def test_exact_company_is_eligible(self):
+		with (
+			patch(
+				"advanced_bank_reconciliation.api.party_company.get_party_company_field",
+				return_value="company_scope",
+			),
+			patch("frappe.get_cached_value", return_value="_Test Company"),
+		):
+			self.assertTrue(
+				is_party_eligible_for_company(
+					"Customer",
+					"_Test Customer",
+					"_Test Company",
+					settings=enabled_settings(),
+				)
+			)
+
+	def test_blank_company_is_shared(self):
+		with (
+			patch(
+				"advanced_bank_reconciliation.api.party_company.get_party_company_field",
+				return_value="company_scope",
+			),
+			patch("frappe.get_cached_value", return_value=None),
+		):
+			self.assertTrue(
+				is_party_eligible_for_company(
+					"Supplier",
+					"_Test Supplier",
+					"_Test Company",
+					settings=enabled_settings(),
+				)
+			)
+
+	def test_other_company_is_ineligible(self):
+		with (
+			patch(
+				"advanced_bank_reconciliation.api.party_company.get_party_company_field",
+				return_value="company",
+			),
+			patch("frappe.get_cached_value", return_value="_Test Company 1"),
+		):
+			self.assertFalse(
+				is_party_eligible_for_company(
+					"Employee",
+					"_Test Employee",
+					"_Test Company",
+					settings=enabled_settings(),
+				)
+			)
+
+	def test_assertion_checks_read_permission_before_company_error(self):
+		doc = frappe._dict(name="_Test Customer")
+		with (
+			patch("frappe.get_doc", return_value=doc),
+			patch("frappe.has_permission", side_effect=frappe.PermissionError),
+			patch("frappe.get_cached_value") as get_company,
+		):
+			with self.assertRaises(frappe.PermissionError):
+				assert_party_eligible_for_company(
+					"Customer",
+					doc.name,
+					"_Test Company",
+					settings=enabled_settings(),
+				)
+			get_company.assert_not_called()
+
+	def test_enabled_policy_requires_company(self):
+		doc = frappe._dict(name="_Test Customer")
+		with (
+			patch("frappe.get_doc", return_value=doc),
+			patch("frappe.has_permission", return_value=True),
+			patch(
+				"advanced_bank_reconciliation.api.party_company.get_party_company_field",
+				return_value="company_scope",
+			),
+		):
+			with self.assertRaisesRegex(
+				frappe.ValidationError,
+				"Company is required when party company filtering is enabled",
+			):
+				assert_party_eligible_for_company(
+					"Customer",
+					doc.name,
+					"",
+					settings=enabled_settings(),
+				)
+
+	def test_search_adds_exact_or_blank_mapping_filter(self):
+		meta = frappe._dict(
+			title_field="customer_name",
+			search_fields="customer_name",
+			translated_doctype=False,
+			fields=[],
+		)
+		meta.get_search_fields = Mock(return_value=["customer_name"])
+		meta.get_field = Mock(
+			side_effect=lambda name: frappe._dict(
+				fieldname=name,
+				fieldtype="Data",
+			)
+		)
+		with (
+			patch("frappe.get_meta", return_value=meta),
+			patch("frappe.get_list", return_value=[["_Test Customer"]]) as get_list,
+			patch(
+				"advanced_bank_reconciliation.api.party_company.get_party_company_field",
+				return_value="company_scope",
+			),
+			patch(
+				"advanced_bank_reconciliation.api.permission.assert_company_access",
+				return_value="_Test Company",
+			),
+			patch("frappe.db.exists", return_value=True),
+		):
+			result = search_parties(
+				"Customer",
+				"_Test",
+				"name",
+				0,
+				20,
+				{"company": "_Test Company", "party_type": "Customer"},
+			)
+		self.assertEqual(result, [["_Test Customer"]])
+		self.assertIn(
+			["Customer", "company_scope", "in", ["_Test Company", ""]],
+			get_list.call_args.kwargs["filters"],
+		)
+
+	def test_search_rejects_unsupported_party_type(self):
+		with patch("frappe.db.exists", return_value=True):
+			with self.assertRaisesRegex(
+				frappe.ValidationError,
+				"Party Type Lead is not supported",
+			):
+				search_parties(
+					"Lead",
+					"",
+					"name",
+					0,
+					20,
+					{"company": "_Test Company", "party_type": "Lead"},
+				)
+
+	def test_disabled_search_has_no_company_filter(self):
+		with (
+			patch("frappe.get_meta") as get_meta,
+			patch("frappe.get_list", return_value=[]) as get_list,
+			patch(
+				"advanced_bank_reconciliation.api.party_company.get_party_company_field",
+				return_value=None,
+			),
+			patch(
+				"advanced_bank_reconciliation.api.permission.assert_company_access",
+				return_value="_Test Company",
+			),
+			patch("frappe.db.exists", return_value=True),
+		):
+			meta = get_meta.return_value
+			meta.title_field = ""
+			meta.search_fields = ""
+			meta.translated_doctype = False
+			meta.fields = []
+			meta.get_search_fields.return_value = []
+			meta.get_field.return_value = None
+			search_parties(
+				"Customer",
+				"",
+				"name",
+				0,
+				20,
+				{"company": "_Test Company", "party_type": "Customer"},
+			)
+		self.assertNotIn(
+			["Customer", "company_scope", "in", ["_Test Company", ""]],
+			get_list.call_args.kwargs["filters"],
+		)
+
+	def test_stale_mapping_fails_closed(self):
+		meta = frappe._dict(fields=[])
+		meta.get_field = lambda fieldname: None
+		with patch("frappe.get_meta", return_value=meta):
+			with self.assertRaisesRegex(
+				frappe.ValidationError,
+				"must be a Link to Company",
+			):
+				get_party_company_field("Customer", settings=enabled_settings())
+
+	def test_each_supported_party_type_uses_its_mapping(self):
+		settings = enabled_settings()
+		expected = {
+			"Customer": "company_scope",
+			"Supplier": "company_scope",
+			"Employee": "company",
+		}
+		meta = frappe._dict()
+		meta.get_field = lambda fieldname: frappe._dict(
+			fieldname=fieldname,
+			fieldtype="Link",
+			options="Company",
+		)
+		with patch("frappe.get_meta", return_value=meta):
+			for party_type, fieldname in expected.items():
+				with self.subTest(party_type=party_type):
+					self.assertEqual(
+						get_party_company_field(
+							party_type,
+							settings=settings,
+						),
+						fieldname,
+					)

--- a/advanced_bank_reconciliation/hooks.py
+++ b/advanced_bank_reconciliation/hooks.py
@@ -163,11 +163,14 @@ before_tests = "advanced_bank_reconciliation.tests.test_utils.before_tests"
 
 # Overriding Methods
 # ------------------------------
-#
-# override_whitelisted_methods = {
-# 	"frappe.desk.doctype.event.event.get_events": "advanced_bank_reconciliation.event.get_events"
-# }
-#
+
+override_whitelisted_methods = {
+    "erpnext.accounts.doctype.bank_reconciliation_tool.bank_reconciliation_tool.update_bank_transaction": (
+        "advanced_bank_reconciliation.advanced_bank_reconciliation.doctype."
+        "advance_bank_reconciliation_tool.advance_bank_reconciliation_tool.update_bank_transaction"
+    )
+}
+
 # each overriding function accepts a `data` argument;
 # generated from the base implementation of the doctype dashboard,
 # along with any modifications made in other Frappe apps

--- a/advanced_bank_reconciliation/public/js/advance_bank_reconciliation_tool/dialog_manager.js
+++ b/advanced_bank_reconciliation/public/js/advance_bank_reconciliation_tool/dialog_manager.js
@@ -1457,7 +1457,7 @@ nexwave.accounts.bank_reconciliation.DialogManager = class DialogManager {
 
 	update_transaction(values) {
 		frappe.call({
-			method: "erpnext.accounts.doctype.bank_reconciliation_tool.bank_reconciliation_tool.update_bank_transaction",
+			method: "advanced_bank_reconciliation.advanced_bank_reconciliation.doctype.advance_bank_reconciliation_tool.advance_bank_reconciliation_tool.update_bank_transaction",
 			args: {
 				bank_transaction_name: this.bank_transaction.name,
 				reference_number: values.reference_number,

--- a/advanced_bank_reconciliation/public/js/advance_bank_reconciliation_tool/dialog_manager.js
+++ b/advanced_bank_reconciliation/public/js/advance_bank_reconciliation_tool/dialog_manager.js
@@ -669,9 +669,12 @@ nexwave.accounts.bank_reconciliation.DialogManager = class DialogManager {
 				get_query: function () {
 					return {
 						filters: {
-							name: ["in", Object.keys(frappe.boot.party_account_types)],
+							name: ["in", ["Customer", "Supplier", "Employee"]],
 						},
 					};
+				},
+				onchange: () => {
+					this.dialog.set_value("party", "");
 				},
 			},
 			{
@@ -682,6 +685,13 @@ nexwave.accounts.bank_reconciliation.DialogManager = class DialogManager {
 				depends_on: "eval:doc.action=='Create Voucher'",
 				mandatory_depends_on:
 					"eval:doc.action=='Create Voucher' && doc.document_type=='Payment Entry'",
+				get_query: () => ({
+					query: "advanced_bank_reconciliation.api.party_company.search_parties",
+					filters: {
+						party_type: this.dialog.get_value("party_type"),
+						company: this.company,
+					},
+				}),
 			},
 			{
 				fieldname: "project",

--- a/bank_rec/src/components/CreateVoucherPanel.vue
+++ b/bank_rec/src/components/CreateVoucherPanel.vue
@@ -10,6 +10,7 @@ import type {
 import EmptyState from "@/components/EmptyState.vue";
 import ErrorState from "@/components/ErrorState.vue";
 import LoadingState from "@/components/LoadingState.vue";
+import PartyAutocomplete from "@/components/PartyAutocomplete.vue";
 import ExternalLink from "~icons/lucide/external-link";
 import Save from "~icons/lucide/save";
 
@@ -267,11 +268,11 @@ watch(
           :options="partyTypeOptions"
         />
 
-        <FormControl
+        <PartyAutocomplete
           v-model="party"
+          :company="defaults.bank_account.company"
+          :party-type="partyType"
           :label="contactLabel"
-          variant="outline"
-          size="md"
         />
 
         <div>

--- a/bank_rec/src/components/PartyAutocomplete.vue
+++ b/bank_rec/src/components/PartyAutocomplete.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onBeforeUnmount, ref, watch } from "vue";
+import { onBeforeUnmount, ref, useId, watch } from "vue";
 import { searchParties } from "@/services/api";
 import type { PartySearchResult } from "@/types/bankRec";
 
@@ -28,6 +28,8 @@ const results = ref<PartySearchResult[]>([]);
 const loading = ref(false);
 const error = ref("");
 const open = ref(false);
+const inputId = useId();
+const listboxId = `${inputId}-listbox`;
 let debounceTimer: ReturnType<typeof setTimeout> | undefined;
 let blurTimer: ReturnType<typeof setTimeout> | undefined;
 let requestId = 0;
@@ -189,11 +191,16 @@ onBeforeUnmount(() => {
 
 <template>
   <div class="relative min-w-0 flex-1">
-    <label v-if="label" class="mb-1.5 block text-sm font-medium text-bank-ink">
+    <label
+      v-if="label"
+      :for="inputId"
+      class="mb-1.5 block text-sm font-medium text-bank-ink"
+    >
       {{ label }}
     </label>
     <div class="relative">
       <input
+        :id="inputId"
         :value="query"
         :placeholder="placeholder"
         :disabled="disabled || !company || !partyType"
@@ -202,6 +209,8 @@ onBeforeUnmount(() => {
         role="combobox"
         :aria-expanded="open && Boolean(results.length)"
         aria-autocomplete="list"
+        aria-haspopup="listbox"
+        :aria-controls="listboxId"
         @input="handleInput"
         @focus="handleFocus"
         @blur="handleBlur"
@@ -218,12 +227,15 @@ onBeforeUnmount(() => {
     </div>
     <div
       v-if="open && results.length"
+      :id="listboxId"
       class="absolute z-30 mt-1 max-h-56 w-full overflow-y-auto rounded-md border border-bank-line bg-white py-1 shadow-lg"
+      role="listbox"
     >
       <button
         v-for="result in results"
         :key="result.value"
         type="button"
+        role="option"
         class="block w-full px-3 py-2 text-left text-sm text-bank-ink hover:bg-bank-surface focus:bg-bank-surface focus:outline-none"
         @mousedown.prevent
         @click="selectResult(result)"

--- a/bank_rec/src/components/PartyAutocomplete.vue
+++ b/bank_rec/src/components/PartyAutocomplete.vue
@@ -1,0 +1,230 @@
+<script setup lang="ts">
+import { onBeforeUnmount, ref, watch } from "vue";
+import { searchParties } from "@/services/api";
+import type { PartySearchResult } from "@/types/bankRec";
+
+const props = withDefaults(
+  defineProps<{
+    company: string;
+    partyType: string;
+    modelValue: string;
+    label?: string;
+    placeholder?: string;
+    disabled?: boolean;
+  }>(),
+  {
+    label: "",
+    placeholder: "Search parties",
+    disabled: false,
+  }
+);
+
+const emit = defineEmits<{
+  "update:modelValue": [value: string];
+}>();
+
+const query = ref(props.modelValue);
+const results = ref<PartySearchResult[]>([]);
+const loading = ref(false);
+const error = ref("");
+const open = ref(false);
+let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+let blurTimer: ReturnType<typeof setTimeout> | undefined;
+let requestId = 0;
+
+function clearDebounce() {
+  if (debounceTimer) {
+    clearTimeout(debounceTimer);
+    debounceTimer = undefined;
+  }
+}
+
+function invalidateSearch() {
+  clearDebounce();
+  requestId += 1;
+  loading.value = false;
+}
+
+async function runSearch(value: string, currentRequestId: number, validate = false) {
+  loading.value = true;
+  error.value = "";
+
+  try {
+    const rows = await searchParties({
+      party_type: props.partyType,
+      company: props.company,
+      txt: value,
+    });
+    if (currentRequestId !== requestId) {
+      return;
+    }
+
+    if (validate) {
+      const exactResult = rows.find((row) => row.value === value);
+      results.value = [];
+      if (!exactResult) {
+        query.value = "";
+        emit("update:modelValue", "");
+      }
+      return;
+    }
+
+    results.value = rows;
+    open.value = true;
+  } catch (searchError) {
+    if (currentRequestId !== requestId) {
+      return;
+    }
+    results.value = [];
+    error.value =
+      searchError instanceof Error ? searchError.message : "Unable to search parties.";
+  } finally {
+    if (currentRequestId === requestId) {
+      loading.value = false;
+    }
+  }
+}
+
+function scheduleSearch(value: string) {
+  invalidateSearch();
+  results.value = [];
+  error.value = "";
+  if (!props.company || !props.partyType) {
+    open.value = false;
+    return;
+  }
+
+  const currentRequestId = requestId;
+  debounceTimer = setTimeout(() => {
+    debounceTimer = undefined;
+    void runSearch(value, currentRequestId);
+  }, 250);
+}
+
+function handleInput(event: Event) {
+  const value = (event.target as HTMLInputElement).value;
+  query.value = value;
+  emit("update:modelValue", value);
+  scheduleSearch(value);
+}
+
+function handleFocus() {
+  if (blurTimer) {
+    clearTimeout(blurTimer);
+    blurTimer = undefined;
+  }
+  if (results.value.length) {
+    open.value = true;
+    return;
+  }
+  scheduleSearch(query.value);
+}
+
+function handleBlur() {
+  blurTimer = setTimeout(() => {
+    open.value = false;
+    blurTimer = undefined;
+  }, 150);
+}
+
+function selectResult(result: PartySearchResult) {
+  invalidateSearch();
+  query.value = result.value;
+  results.value = [];
+  error.value = "";
+  open.value = false;
+  emit("update:modelValue", result.value);
+}
+
+watch(
+  () => props.modelValue,
+  (value) => {
+    if (value !== query.value) {
+      query.value = value;
+    }
+  }
+);
+
+watch(
+  () => [props.company, props.partyType] as const,
+  ([company, partyType]) => {
+    invalidateSearch();
+    results.value = [];
+    error.value = "";
+    open.value = false;
+
+    if (!company || !partyType) {
+      query.value = "";
+      if (props.modelValue) {
+        emit("update:modelValue", "");
+      }
+      return;
+    }
+
+    const value = props.modelValue;
+    if (!value) {
+      query.value = "";
+      return;
+    }
+
+    query.value = value;
+    const currentRequestId = requestId;
+    void runSearch(value, currentRequestId, true);
+  },
+  { immediate: true }
+);
+
+onBeforeUnmount(() => {
+  invalidateSearch();
+  if (blurTimer) {
+    clearTimeout(blurTimer);
+  }
+});
+</script>
+
+<template>
+  <div class="relative min-w-0 flex-1">
+    <label v-if="label" class="mb-1.5 block text-sm font-medium text-bank-ink">
+      {{ label }}
+    </label>
+    <div class="relative">
+      <input
+        :value="query"
+        :placeholder="placeholder"
+        :disabled="disabled || !company || !partyType"
+        class="h-9 w-full min-w-0 rounded-md border border-bank-line bg-white px-3 pr-9 text-sm outline-none transition placeholder:text-bank-muted focus:border-bank-accent focus:ring-2 focus:ring-blue-100 disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-bank-muted"
+        autocomplete="off"
+        role="combobox"
+        :aria-expanded="open && Boolean(results.length)"
+        aria-autocomplete="list"
+        @input="handleInput"
+        @focus="handleFocus"
+        @blur="handleBlur"
+      />
+      <div
+        v-if="loading"
+        class="absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin rounded-full border-2 border-gray-300 border-t-bank-accent"
+        role="status"
+        aria-label="Loading parties"
+      />
+    </div>
+    <div v-if="error" class="mt-1 text-xs text-red-600">
+      {{ error }}
+    </div>
+    <div
+      v-if="open && results.length"
+      class="absolute z-30 mt-1 max-h-56 w-full overflow-y-auto rounded-md border border-bank-line bg-white py-1 shadow-lg"
+    >
+      <button
+        v-for="result in results"
+        :key="result.value"
+        type="button"
+        class="block w-full px-3 py-2 text-left text-sm text-bank-ink hover:bg-bank-surface focus:bg-bank-surface focus:outline-none"
+        @mousedown.prevent
+        @click="selectResult(result)"
+      >
+        {{ result.label }}
+      </button>
+    </div>
+  </div>
+</template>

--- a/bank_rec/src/components/PartyAutocomplete.vue
+++ b/bank_rec/src/components/PartyAutocomplete.vue
@@ -33,6 +33,7 @@ const listboxId = `${inputId}-listbox`;
 let debounceTimer: ReturnType<typeof setTimeout> | undefined;
 let blurTimer: ReturnType<typeof setTimeout> | undefined;
 let requestId = 0;
+let validatedValue = "";
 
 function clearDebounce() {
   if (debounceTimer) {
@@ -66,8 +67,11 @@ async function runSearch(value: string, currentRequestId: number, validate = fal
       const exactResult = rows.find((row) => row.value === value);
       results.value = [];
       if (!exactResult) {
+        validatedValue = "";
         query.value = "";
         emit("update:modelValue", "");
+      } else {
+        validatedValue = value;
       }
       return;
     }
@@ -106,6 +110,9 @@ function scheduleSearch(value: string) {
 
 function handleInput(event: Event) {
   const value = (event.target as HTMLInputElement).value;
+  if (value !== validatedValue) {
+    validatedValue = "";
+  }
   query.value = value;
   emit("update:modelValue", value);
   scheduleSearch(value);
@@ -127,11 +134,19 @@ function handleBlur() {
   blurTimer = setTimeout(() => {
     open.value = false;
     blurTimer = undefined;
+    const value = query.value;
+    if (!value || value === validatedValue || !props.company || !props.partyType) {
+      return;
+    }
+    invalidateSearch();
+    const currentRequestId = requestId;
+    void runSearch(value, currentRequestId, true);
   }, 150);
 }
 
 function selectResult(result: PartySearchResult) {
   invalidateSearch();
+  validatedValue = result.value;
   query.value = result.value;
   results.value = [];
   error.value = "";
@@ -148,6 +163,11 @@ watch(
       error.value = "";
       open.value = false;
       query.value = value;
+      if (!value || !props.company || !props.partyType) {
+        return;
+      }
+      const currentRequestId = requestId;
+      void runSearch(value, currentRequestId, true);
     }
   }
 );
@@ -159,6 +179,7 @@ watch(
     results.value = [];
     error.value = "";
     open.value = false;
+    validatedValue = "";
 
     if (!company || !partyType) {
       query.value = "";

--- a/bank_rec/src/components/PartyAutocomplete.vue
+++ b/bank_rec/src/components/PartyAutocomplete.vue
@@ -54,6 +54,7 @@ async function runSearch(value: string, currentRequestId: number, validate = fal
       party_type: props.partyType,
       company: props.company,
       txt: value,
+      exact_party: validate ? value : undefined,
     });
     if (currentRequestId !== requestId) {
       return;
@@ -140,6 +141,10 @@ watch(
   () => props.modelValue,
   (value) => {
     if (value !== query.value) {
+      invalidateSearch();
+      results.value = [];
+      error.value = "";
+      open.value = false;
       query.value = value;
     }
   }

--- a/bank_rec/src/components/UpdateTransactionPanel.vue
+++ b/bank_rec/src/components/UpdateTransactionPanel.vue
@@ -3,6 +3,7 @@ import { computed, ref, watch } from "vue";
 import type { BankTransaction } from "@/types/bankRec";
 import ErrorState from "@/components/ErrorState.vue";
 import LoadingState from "@/components/LoadingState.vue";
+import PartyAutocomplete from "@/components/PartyAutocomplete.vue";
 import Save from "~icons/lucide/save";
 
 const props = defineProps<{
@@ -86,11 +87,11 @@ watch(
           :options="partyTypeOptions"
         />
 
-        <FormControl
+        <PartyAutocomplete
           v-model="party"
+          :company="transaction.company || ''"
+          :party-type="partyType"
           label="Party"
-          variant="outline"
-          size="md"
         />
       </div>
 

--- a/bank_rec/src/pages/CashCodingPage.vue
+++ b/bank_rec/src/pages/CashCodingPage.vue
@@ -5,6 +5,7 @@ import BankAccountFilters from "@/components/BankAccountFilters.vue";
 import EmptyState from "@/components/EmptyState.vue";
 import ErrorState from "@/components/ErrorState.vue";
 import LoadingState from "@/components/LoadingState.vue";
+import PartyAutocomplete from "@/components/PartyAutocomplete.vue";
 import ReconcileProgressDialog from "@/components/ReconcileProgressDialog.vue";
 import { getCashCodingRows, submitCashCoding } from "@/services/api";
 import { useBankRecStore } from "@/stores/bankRec";
@@ -161,6 +162,11 @@ function markDirty(name: string) {
   const next = new Set(dirtyRows.value);
   next.add(name);
   dirtyRows.value = next;
+}
+
+function changePartyType(row: CashCodingRow) {
+  row.party = "";
+  markDirty(row.transaction.name);
 }
 
 function clearDirty(names?: string[]) {
@@ -555,17 +561,19 @@ onBeforeRouteLeave(() => guardDiscard());
                   <select
                     v-model="row.party_type"
                     class="h-9 w-[6.75rem] shrink-0 rounded-md border border-bank-line bg-white px-2 text-sm outline-none focus:border-bank-accent focus:ring-2 focus:ring-blue-100"
-                    @change="markDirty(row.transaction.name)"
+                    @change="changePartyType(row)"
                   >
                     <option value="">None</option>
                     <option value="Customer">Customer</option>
                     <option value="Supplier">Supplier</option>
                     <option value="Employee">Employee</option>
                   </select>
-                  <input
+                  <PartyAutocomplete
                     v-model="row.party"
-                    class="h-9 min-w-0 flex-1 rounded-md border border-bank-line px-2 text-sm outline-none focus:border-bank-accent focus:ring-2 focus:ring-blue-100"
-                    @input="markDirty(row.transaction.name)"
+                    :company="row.transaction.company || store.selectedCompany"
+                    :party-type="row.party_type"
+                    placeholder="Party"
+                    @update:model-value="markDirty(row.transaction.name)"
                   />
                 </div>
               </td>

--- a/bank_rec/src/services/api.ts
+++ b/bank_rec/src/services/api.ts
@@ -180,6 +180,7 @@ export async function searchParties(params: {
   company: string;
   txt?: string;
   page_len?: number;
+  exact_party?: string;
 }): Promise<PartySearchResult[]> {
   const rows = await call<string[][]>(partyCompanyApiPath, "search_parties", {
     doctype: params.party_type,
@@ -187,6 +188,7 @@ export async function searchParties(params: {
     searchfield: "name",
     start: 0,
     page_len: params.page_len || 20,
+    exact_party: params.exact_party,
     filters: {
       party_type: params.party_type,
       company: params.company,

--- a/bank_rec/src/services/api.ts
+++ b/bank_rec/src/services/api.ts
@@ -12,6 +12,7 @@ import type {
   MatchCandidatesResponse,
   MatchVoucherSelection,
   MatchedTransactionsResponse,
+  PartySearchResult,
   StatementSummary,
   SubmitMatchResponse,
   TransactionContext,
@@ -44,6 +45,8 @@ const createVoucherApiPath =
 const cashCodingApiPath =
   "/api/method/advanced_bank_reconciliation.api.cash_coding.";
 const matchedApiPath = "/api/method/advanced_bank_reconciliation.api.matched.";
+const partyCompanyApiPath =
+  "/api/method/advanced_bank_reconciliation.api.party_company.";
 
 function getCsrfToken() {
   return window.csrf_token || "";
@@ -170,6 +173,29 @@ export function getTransactionContext(bank_transaction_name: string) {
 
 export function getBankRules(bank_account?: string) {
   return call<BankRule[]>(bankRecApiPath, "get_bank_rules", { bank_account });
+}
+
+export async function searchParties(params: {
+  party_type: string;
+  company: string;
+  txt?: string;
+  page_len?: number;
+}): Promise<PartySearchResult[]> {
+  const rows = await call<string[][]>(partyCompanyApiPath, "search_parties", {
+    doctype: params.party_type,
+    txt: params.txt || "",
+    searchfield: "name",
+    start: 0,
+    page_len: params.page_len || 20,
+    filters: {
+      party_type: params.party_type,
+      company: params.company,
+    },
+  });
+  return rows.map((row) => ({
+    value: row[0],
+    label: row[1] && row[1] !== row[0] ? `${row[1]} (${row[0]})` : row[0],
+  }));
 }
 
 export function getMatchCandidates(params: {

--- a/bank_rec/src/types/bankRec.ts
+++ b/bank_rec/src/types/bankRec.ts
@@ -102,6 +102,11 @@ export interface BankRule {
   desk_url: string;
 }
 
+export interface PartySearchResult {
+  value: string;
+  label: string;
+}
+
 export type TransactionStatusFilter = "unreconciled" | "reconciled" | "all";
 
 export type MatchConfidence = "high" | "medium" | "low";

--- a/docs/superpowers/plans/2026-07-25-party-company-filter.md
+++ b/docs/superpowers/plans/2026-07-25-party-company-filter.md
@@ -1,0 +1,1481 @@
+# Configurable Party Company Filtering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an opt-in, explicitly mapped company policy for Customer, Supplier, and Employee selections across every Advanced Bank Reconciliation workflow.
+
+**Architecture:** A new `api/party_company.py` module owns mapping validation, eligibility checks, and permission-aware party search. The Single settings DocType stores one explicit Company Link fieldname per supported Party Type. Legacy, modern, direct API, and bank-rule mutation paths all delegate to the same server policy, while the two frontends use the same search endpoint for suggestions.
+
+**Tech Stack:** Frappe v15, ERPNext v15, Python 3, MariaDB, Frappe Desk JavaScript, Vue 3, TypeScript, Vite, `FrappeTestCase`.
+
+## Global Constraints
+
+- The feature is disabled by default, and disabled behavior remains global.
+- Supported Party Types are exactly `Customer`, `Supplier`, and `Employee`.
+- Customer and Supplier mappings have no default. Employee defaults to `company`.
+- A configured mapping is valid only when its DocField exists, has `fieldtype == "Link"`, and has `options == "Company"`.
+- Administrators select mappings explicitly. Never infer or auto-select a Customer or Supplier field.
+- A party is eligible when its mapped company equals the reconciliation company or is blank/null.
+- When filtering is enabled, missing or stale configuration fails closed.
+- Existing documents and ABR Bank Rules are not rewritten.
+- All party mutation paths remain server-authoritative and preserve existing read permissions.
+- Search must retain normal Frappe read/select permissions, enabled/disabled behavior, and text matching.
+- Enabling the policy is blocked when any enabled ABR Bank Rule with a party is incompatible.
+- Error messages must not disclose party records before read permission is established.
+- Public repository artifacts must contain no customer names, site URLs, private fieldnames, ticket identifiers, contact details, dates tied to customers, or identifying transaction data.
+- Use tabs in Python files and the existing formatter conventions.
+- Use `FrappeTestCase`; do not use pytest.
+- Commit subjects use Conventional Commits with `fix:` so semantic-release produces a patch.
+- Do not merge or deploy as part of this plan.
+
+---
+
+### Task 1: Settings, Metadata Validation, Eligibility, and Search
+
+**Files:**
+
+- Create: `advanced_bank_reconciliation/api/party_company.py`
+- Create: `advanced_bank_reconciliation/api/test_party_company.py`
+- Modify: `advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_settings/advance_bank_reconciliation_settings.json`
+- Modify: `advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_settings/advance_bank_reconciliation_settings.py`
+- Modify: `advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_settings/advance_bank_reconciliation_settings.js`
+- Modify: `advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_settings/test_advance_bank_reconciliation_settings.py`
+
+**Interfaces:**
+
+- Produces:
+  - `SUPPORTED_PARTY_TYPES: tuple[str, ...]`
+  - `PARTY_COMPANY_SETTING_FIELDS: dict[str, str]`
+  - `get_company_link_fields(party_type: str) -> list[dict[str, str]]`
+  - `get_party_company_field(party_type: str, settings=None) -> str | None`
+  - `is_party_eligible_for_company(party_type: str, party: str, company: str, settings=None) -> bool`
+  - `assert_party_eligible_for_company(party_type: str, party: str, company: str, user: str | None = None, settings=None)`
+  - `search_parties(doctype, txt, searchfield, start, page_len, filters) -> list[list[str]]`
+  - `validate_party_company_settings(settings) -> None`
+  - `validate_enabled_bank_rules(settings, limit: int = 20) -> None`
+- Consumes:
+  - `Advance Bank Reconciliation Settings.filter_parties_by_company`
+  - `Advance Bank Reconciliation Settings.customer_company_field`
+  - `Advance Bank Reconciliation Settings.supplier_company_field`
+  - `Advance Bank Reconciliation Settings.employee_company_field`
+
+- [ ] **Step 1: Add failing metadata and settings tests**
+
+Replace the empty settings test with `FrappeTestCase` tests using generic metadata stubs:
+
+```python
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from advanced_bank_reconciliation.api.party_company import (
+	get_company_link_fields,
+	validate_party_company_settings,
+)
+
+
+def field(fieldname, fieldtype="Link", options="Company", label=None):
+	return frappe._dict(
+		fieldname=fieldname,
+		fieldtype=fieldtype,
+		options=options,
+		label=label or fieldname.replace("_", " ").title(),
+	)
+
+
+class TestAdvanceBankReconciliationSettings(FrappeTestCase):
+	def test_disabled_settings_allow_blank_mappings(self):
+		settings = frappe._dict(filter_parties_by_company=0)
+		validate_party_company_settings(settings)
+
+	def test_enabled_settings_require_every_mapping(self):
+		settings = frappe._dict(
+			filter_parties_by_company=1,
+			customer_company_field="",
+			supplier_company_field="supplier_scope",
+			employee_company_field="company",
+		)
+		with self.assertRaisesRegex(
+			frappe.ValidationError,
+			"Configure the Customer Company Field",
+		):
+			validate_party_company_settings(settings)
+
+	def test_enabled_settings_accept_company_links(self):
+		settings = frappe._dict(
+			filter_parties_by_company=1,
+			customer_company_field="customer_scope",
+			supplier_company_field="supplier_scope",
+			employee_company_field="company",
+		)
+		metas = {
+			"Customer": frappe._dict(fields=[field("customer_scope")]),
+			"Supplier": frappe._dict(fields=[field("supplier_scope")]),
+			"Employee": frappe._dict(fields=[field("company")]),
+		}
+		for meta in metas.values():
+			meta.get_field = lambda fieldname, meta=meta: next(
+				(row for row in meta.fields if row.fieldname == fieldname),
+				None,
+			)
+		with patch("frappe.get_meta", side_effect=lambda doctype: metas[doctype]):
+			validate_party_company_settings(settings)
+
+	def test_non_company_link_mapping_is_rejected(self):
+		settings = frappe._dict(
+			filter_parties_by_company=1,
+			customer_company_field="customer_scope",
+			supplier_company_field="supplier_scope",
+			employee_company_field="company",
+		)
+		meta = frappe._dict(fields=[field("customer_scope", options="Customer Group")])
+		meta.get_field = lambda fieldname: next(
+			(row for row in meta.fields if row.fieldname == fieldname),
+			None,
+		)
+		with patch("frappe.get_meta", return_value=meta):
+			with self.assertRaisesRegex(
+				frappe.ValidationError,
+				"must be a Link to Company",
+			):
+				validate_party_company_settings(settings)
+
+	def test_candidate_fields_only_include_company_links(self):
+		meta = frappe._dict(
+			fields=[
+				field("company_scope", label="Company Scope"),
+				field("represents_company"),
+				field("territory", options="Territory"),
+				field("notes", fieldtype="Data", options=None),
+			]
+		)
+		with patch("frappe.get_meta", return_value=meta):
+			self.assertEqual(
+				get_company_link_fields("Customer"),
+				[
+					{"fieldname": "company_scope", "label": "Company Scope"},
+					{"fieldname": "represents_company", "label": "Represents Company"},
+				],
+			)
+```
+
+Also assert the JSON schema directly:
+
+```python
+	def test_mapping_defaults_are_safe(self):
+		meta = frappe.get_meta("Advance Bank Reconciliation Settings")
+		self.assertEqual(meta.get_field("filter_parties_by_company").default, "0")
+		self.assertFalse(meta.get_field("customer_company_field").default)
+		self.assertFalse(meta.get_field("supplier_company_field").default)
+		self.assertEqual(meta.get_field("employee_company_field").default, "company")
+```
+
+- [ ] **Step 2: Add failing policy and search tests**
+
+Create `api/test_party_company.py` with table-driven tests for the exact policy:
+
+```python
+from unittest.mock import Mock, patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from advanced_bank_reconciliation.api.party_company import (
+	assert_party_eligible_for_company,
+	get_party_company_field,
+	is_party_eligible_for_company,
+	search_parties,
+)
+
+
+def enabled_settings():
+	return frappe._dict(
+		filter_parties_by_company=1,
+		customer_company_field="company_scope",
+		supplier_company_field="company_scope",
+		employee_company_field="company",
+	)
+
+
+class TestPartyCompanyPolicy(FrappeTestCase):
+	def test_disabled_policy_returns_no_mapping(self):
+		settings = frappe._dict(filter_parties_by_company=0)
+		self.assertIsNone(get_party_company_field("Customer", settings=settings))
+
+	def test_exact_company_is_eligible(self):
+		with (
+			patch(
+				"advanced_bank_reconciliation.api.party_company.get_party_company_field",
+				return_value="company_scope",
+			),
+			patch("frappe.get_cached_value", return_value="_Test Company"),
+		):
+			self.assertTrue(
+				is_party_eligible_for_company(
+					"Customer",
+					"_Test Customer",
+					"_Test Company",
+					settings=enabled_settings(),
+				)
+			)
+
+	def test_blank_company_is_shared(self):
+		with (
+			patch(
+				"advanced_bank_reconciliation.api.party_company.get_party_company_field",
+				return_value="company_scope",
+			),
+			patch("frappe.get_cached_value", return_value=None),
+		):
+			self.assertTrue(
+				is_party_eligible_for_company(
+					"Supplier",
+					"_Test Supplier",
+					"_Test Company",
+					settings=enabled_settings(),
+				)
+			)
+
+	def test_other_company_is_ineligible(self):
+		with (
+			patch(
+				"advanced_bank_reconciliation.api.party_company.get_party_company_field",
+				return_value="company",
+			),
+			patch("frappe.get_cached_value", return_value="_Test Company 1"),
+		):
+			self.assertFalse(
+				is_party_eligible_for_company(
+					"Employee",
+					"_Test Employee",
+					"_Test Company",
+					settings=enabled_settings(),
+				)
+			)
+
+	def test_assertion_checks_read_permission_before_company_error(self):
+		doc = frappe._dict(name="_Test Customer")
+		with (
+			patch("frappe.get_doc", return_value=doc),
+			patch("frappe.has_permission", side_effect=frappe.PermissionError),
+			patch("frappe.get_cached_value") as get_company,
+		):
+			with self.assertRaises(frappe.PermissionError):
+				assert_party_eligible_for_company(
+					"Customer",
+					doc.name,
+					"_Test Company",
+					settings=enabled_settings(),
+				)
+			get_company.assert_not_called()
+
+	def test_enabled_policy_requires_company(self):
+		doc = frappe._dict(name="_Test Customer")
+		with (
+			patch("frappe.get_doc", return_value=doc),
+			patch("frappe.has_permission", return_value=True),
+			patch(
+				"advanced_bank_reconciliation.api.party_company.get_party_company_field",
+				return_value="company_scope",
+			),
+		):
+			with self.assertRaisesRegex(
+				frappe.ValidationError,
+				"Company is required when party company filtering is enabled",
+			):
+				assert_party_eligible_for_company(
+					"Customer",
+					doc.name,
+					"",
+					settings=enabled_settings(),
+				)
+
+	def test_search_adds_exact_or_blank_mapping_filter(self):
+		meta = frappe._dict(
+			title_field="customer_name",
+			search_fields="customer_name",
+			translated_doctype=False,
+			fields=[],
+		)
+		meta.get_search_fields = Mock(return_value=["customer_name"])
+		meta.get_field = Mock(
+			side_effect=lambda name: frappe._dict(
+				fieldname=name,
+				fieldtype="Data",
+			)
+		)
+		with (
+			patch("frappe.get_meta", return_value=meta),
+			patch("frappe.get_list", return_value=[["_Test Customer"]]) as get_list,
+			patch(
+				"advanced_bank_reconciliation.api.party_company.get_party_company_field",
+				return_value="company_scope",
+			),
+			patch(
+				"advanced_bank_reconciliation.api.permission.assert_company_access",
+				return_value="_Test Company",
+			),
+			patch("frappe.db.exists", return_value=True),
+		):
+			result = search_parties(
+				"Customer",
+				"_Test",
+				"name",
+				0,
+				20,
+				{"company": "_Test Company", "party_type": "Customer"},
+			)
+		self.assertEqual(result, [["_Test Customer"]])
+		self.assertIn(
+			["Customer", "company_scope", "in", ["_Test Company", ""]],
+			get_list.call_args.kwargs["filters"],
+		)
+
+	def test_search_rejects_unsupported_party_type(self):
+		with patch("frappe.db.exists", return_value=True):
+			with self.assertRaisesRegex(
+				frappe.ValidationError,
+				"Party Type Lead is not supported",
+			):
+				search_parties(
+					"Lead",
+					"",
+					"name",
+					0,
+					20,
+					{"company": "_Test Company", "party_type": "Lead"},
+				)
+```
+
+Add these explicit cases to the same class:
+
+```python
+	def test_disabled_search_has_no_company_filter(self):
+		with (
+			patch("frappe.get_meta") as get_meta,
+			patch("frappe.get_list", return_value=[]) as get_list,
+			patch(
+				"advanced_bank_reconciliation.api.party_company.get_party_company_field",
+				return_value=None,
+			),
+			patch(
+				"advanced_bank_reconciliation.api.permission.assert_company_access",
+				return_value="_Test Company",
+			),
+			patch("frappe.db.exists", return_value=True),
+		):
+			meta = get_meta.return_value
+			meta.title_field = ""
+			meta.search_fields = ""
+			meta.translated_doctype = False
+			meta.fields = []
+			meta.get_search_fields.return_value = []
+			meta.get_field.return_value = None
+			search_parties(
+				"Customer",
+				"",
+				"name",
+				0,
+				20,
+				{"company": "_Test Company", "party_type": "Customer"},
+			)
+		self.assertNotIn(
+			["Customer", "company_scope", "in", ["_Test Company", ""]],
+			get_list.call_args.kwargs["filters"],
+		)
+
+	def test_stale_mapping_fails_closed(self):
+		meta = frappe._dict(fields=[])
+		meta.get_field = lambda fieldname: None
+		with patch("frappe.get_meta", return_value=meta):
+			with self.assertRaisesRegex(
+				frappe.ValidationError,
+				"must be a Link to Company",
+			):
+				get_party_company_field("Customer", settings=enabled_settings())
+
+	def test_each_supported_party_type_uses_its_mapping(self):
+		settings = enabled_settings()
+		expected = {
+			"Customer": "company_scope",
+			"Supplier": "company_scope",
+			"Employee": "company",
+		}
+		meta = frappe._dict()
+		meta.get_field = lambda fieldname: frappe._dict(
+			fieldname=fieldname,
+			fieldtype="Link",
+			options="Company",
+		)
+		with patch("frappe.get_meta", return_value=meta):
+			for party_type, fieldname in expected.items():
+				with self.subTest(party_type=party_type):
+					self.assertEqual(
+						get_party_company_field(
+							party_type,
+							settings=settings,
+						),
+						fieldname,
+					)
+```
+
+- [ ] **Step 3: Run the focused tests and confirm they fail**
+
+Run:
+
+```bash
+bench --site demo.localhost run-tests --app advanced_bank_reconciliation --module advanced_bank_reconciliation.advanced_bank_reconciliation.doctype.advance_bank_reconciliation_settings.test_advance_bank_reconciliation_settings
+bench --site demo.localhost run-tests --app advanced_bank_reconciliation --module advanced_bank_reconciliation.api.test_party_company
+```
+
+Expected: failures because the settings fields and `party_company` interfaces do not exist.
+
+- [ ] **Step 4: Add the settings fields**
+
+Add this field order after `compact_matching_vouchers_table`:
+
+```json
+"party_company_filtering_section",
+"filter_parties_by_company",
+"customer_company_field",
+"supplier_company_field",
+"employee_company_field"
+```
+
+Add the fields:
+
+```json
+{
+ "fieldname": "party_company_filtering_section",
+ "fieldtype": "Section Break",
+ "label": "Party Company Filtering"
+},
+{
+ "default": "0",
+ "description": "Restrict Customer, Supplier, and Employee selections to the reconciliation company while allowing records with a blank company as shared.",
+ "fieldname": "filter_parties_by_company",
+ "fieldtype": "Check",
+ "label": "Filter Parties by Company"
+},
+{
+ "depends_on": "eval:doc.filter_parties_by_company",
+ "description": "Link field on Customer that identifies the owning company.",
+ "fieldname": "customer_company_field",
+ "fieldtype": "Autocomplete",
+ "label": "Customer Company Field",
+ "mandatory_depends_on": "eval:doc.filter_parties_by_company"
+},
+{
+ "depends_on": "eval:doc.filter_parties_by_company",
+ "description": "Link field on Supplier that identifies the owning company.",
+ "fieldname": "supplier_company_field",
+ "fieldtype": "Autocomplete",
+ "label": "Supplier Company Field",
+ "mandatory_depends_on": "eval:doc.filter_parties_by_company"
+},
+{
+ "default": "company",
+ "depends_on": "eval:doc.filter_parties_by_company",
+ "description": "Link field on Employee that identifies the owning company.",
+ "fieldname": "employee_company_field",
+ "fieldtype": "Autocomplete",
+ "label": "Employee Company Field",
+ "mandatory_depends_on": "eval:doc.filter_parties_by_company"
+}
+```
+
+Update the generated type block with the four new field annotations without changing code outside the block.
+
+- [ ] **Step 5: Implement the authoritative party policy**
+
+Implement these constants and helpers in `api/party_company.py`:
+
+```python
+SUPPORTED_PARTY_TYPES = ("Customer", "Supplier", "Employee")
+PARTY_COMPANY_SETTING_FIELDS = {
+	"Customer": "customer_company_field",
+	"Supplier": "supplier_company_field",
+	"Employee": "employee_company_field",
+}
+```
+
+Implementation rules:
+
+```python
+def _get_settings(settings=None):
+	return settings or frappe.get_cached_doc("Advance Bank Reconciliation Settings")
+
+
+def _require_supported_party_type(party_type):
+	if party_type not in SUPPORTED_PARTY_TYPES:
+		frappe.throw(
+			_("Party Type {0} is not supported in Bank Rec.").format(party_type)
+		)
+
+
+def _validate_company_link_field(party_type, fieldname):
+	field = frappe.get_meta(party_type).get_field(fieldname)
+	if not field or field.fieldtype != "Link" or field.options != "Company":
+		frappe.throw(
+			_("Field {0} on {1} must be a Link to Company.").format(
+				fieldname,
+				party_type,
+			)
+		)
+	return field
+```
+
+`get_party_company_field` returns `None` immediately when filtering is disabled. When enabled, it validates the corresponding configured field and throws `Configure the <Party Type> Company Field in Advance Bank Reconciliation Settings.` if blank.
+
+`assert_party_eligible_for_company` must:
+
+1. Validate supported type and party/type pairing.
+2. Load the party document and call `frappe.has_permission(..., throw=True)`.
+3. Return the document immediately when filtering is disabled.
+4. Require company when filtering is enabled.
+5. Read the mapped company with `frappe.get_cached_value(party_type, party, fieldname)`.
+6. Return the document when the value is blank or equal to company.
+7. Throw `<Party Type> <party> is not available for company <company>.` otherwise.
+
+`is_party_eligible_for_company` applies the same mapped-field comparison without replacing the permission check in the assertion helper.
+
+Implement `search_parties` with:
+
+- Parsed dict filters containing `company` and optional `party_type`.
+- The allowlist check before querying.
+- A function-local import of `assert_company_access` to avoid a circular import with `api/permission.py`.
+- `assert_company_access(company)` for every search. Filtering enabled without a company fails with `Company is required when party company filtering is enabled.`
+- `frappe.get_list`, never `frappe.get_all`, so read/select and user permissions remain active.
+- Standard fields `name`, title field, and metadata search fields when they are valid text-like fields.
+- Standard `enabled = 1` and `disabled != 1` filters when those Check fields exist.
+- Text `or_filters` for name, title field, and search fields.
+- The company filter exactly `[doctype, mapped_field, "in", [company, ""]]`, which Frappe v15 coalesces to include null values.
+- `start` and `page_len` pagination.
+- No caching of results.
+
+- [ ] **Step 6: Validate settings and enabled rules**
+
+In the settings controller:
+
+```python
+def validate(self):
+	validate_party_company_settings(self)
+	validate_enabled_bank_rules(self)
+```
+
+`validate_party_company_settings` returns immediately when disabled. When enabled, it resolves all three mappings with the settings document passed in.
+
+`validate_enabled_bank_rules` returns immediately when disabled. Otherwise it reads enabled rules with nonblank `party_type` and `party`, evaluates each against `rule.company` using the unsaved settings document, and rejects the save with at most 20 rule names plus an overflow count. The message must direct the administrator to correct or disable those rules. It must not update the rules.
+
+- [ ] **Step 7: Populate safe Autocomplete choices**
+
+In the settings client script:
+
+```javascript
+const partyCompanyFields = {
+	customer_company_field: "Customer",
+	supplier_company_field: "Supplier",
+	employee_company_field: "Employee",
+};
+
+frappe.ui.form.on("Advance Bank Reconciliation Settings", {
+	async refresh(frm) {
+		for (const [fieldname, partyType] of Object.entries(partyCompanyFields)) {
+			const { message = [] } = await frappe.call({
+				method: "advanced_bank_reconciliation.api.party_company.get_company_link_fields",
+				args: { party_type: partyType },
+			});
+			frm.fields_dict[fieldname].set_data(
+				message.map((row) => ({
+					label: `${row.label} (${row.fieldname})`,
+					value: row.fieldname,
+				}))
+			);
+		}
+	},
+});
+```
+
+Whitelist `get_company_link_fields` and require read permission on the settings DocType before returning metadata.
+
+- [ ] **Step 8: Run focused tests and migrate the local test site**
+
+Run:
+
+```bash
+bench --site demo.localhost migrate
+bench --site demo.localhost run-tests --app advanced_bank_reconciliation --module advanced_bank_reconciliation.advanced_bank_reconciliation.doctype.advance_bank_reconciliation_settings.test_advance_bank_reconciliation_settings
+bench --site demo.localhost run-tests --app advanced_bank_reconciliation --module advanced_bank_reconciliation.api.test_party_company
+```
+
+Expected: all Task 1 tests pass.
+
+- [ ] **Step 9: Commit Task 1**
+
+```bash
+git add advanced_bank_reconciliation/api/party_company.py \
+  advanced_bank_reconciliation/api/test_party_company.py \
+  advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_settings
+git commit -m "fix: add configurable party company policy"
+```
+
+---
+
+### Task 2: Server-Side Enforcement Across Every Mutation Path
+
+**Files:**
+
+- Modify: `advanced_bank_reconciliation/api/permission.py`
+- Modify: `advanced_bank_reconciliation/api/create_voucher.py`
+- Modify: `advanced_bank_reconciliation/api/matching.py`
+- Modify: `advanced_bank_reconciliation/api/cash_coding.py`
+- Modify: `advanced_bank_reconciliation/api/test_bank_rec.py`
+- Modify: `advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/advance_bank_reconciliation_tool.py`
+- Create: `advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/tests/test_party_company_enforcement.py`
+
+**Interfaces:**
+
+- Consumes:
+  - `assert_party_eligible_for_company(party_type, party, company, user=None, settings=None)`
+- Produces:
+  - `assert_party_access(party_type=None, party=None, company=None, user=None)`
+- Guarantees:
+  - Every party-bearing legacy and modern mutation derives or receives the Bank Transaction company and validates before creating or saving a document.
+
+- [ ] **Step 1: Add failing permission delegation tests**
+
+Add to `api/test_party_company.py`:
+
+```python
+from advanced_bank_reconciliation.api.permission import assert_party_access
+
+
+class TestPartyCompanyPermissionIntegration(FrappeTestCase):
+	def test_assert_party_access_delegates_company_policy(self):
+		doc = frappe._dict(name="_Test Customer")
+		with patch(
+			"advanced_bank_reconciliation.api.permission.assert_party_eligible_for_company",
+			return_value=doc,
+		) as assert_eligible:
+			self.assertIs(
+				assert_party_access(
+					"Customer",
+					"_Test Customer",
+					company="_Test Company",
+				),
+				doc,
+			)
+		assert_eligible.assert_called_once_with(
+			"Customer",
+			"_Test Customer",
+			"_Test Company",
+			user=frappe.session.user,
+		)
+```
+
+Keep the existing pairing errors for missing Party Type or Party.
+
+- [ ] **Step 2: Add failing legacy mutation tests**
+
+Create `tests/test_party_company_enforcement.py` with mocks that prove validation occurs before mutation:
+
+```python
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from advanced_bank_reconciliation.advanced_bank_reconciliation.doctype.advance_bank_reconciliation_tool.advance_bank_reconciliation_tool import (
+	create_journal_entry_bts,
+	create_payment_entry_bts,
+	update_bank_transaction,
+)
+
+MODULE = (
+	"advanced_bank_reconciliation.advanced_bank_reconciliation.doctype."
+	"advance_bank_reconciliation_tool.advance_bank_reconciliation_tool"
+)
+
+
+class TestLegacyPartyCompanyEnforcement(FrappeTestCase):
+	def test_update_validates_against_transaction_company(self):
+		transaction = frappe._dict(
+			name="_Test Bank Transaction",
+			company="_Test Company",
+			reference_number="",
+			party_type="",
+			party="",
+		)
+		transaction.save = lambda: None
+		with (
+			patch(f"{MODULE}.frappe.get_doc", return_value=transaction),
+			patch(f"{MODULE}.assert_party_access") as assert_party,
+			patch(f"{MODULE}.frappe.db.get_all", return_value=[transaction]),
+		):
+			update_bank_transaction(
+				transaction.name,
+				"REF",
+				"Customer",
+				"_Test Customer",
+			)
+		assert_party.assert_called_once_with(
+			"Customer",
+			"_Test Customer",
+			company="_Test Company",
+		)
+
+	def test_journal_entry_rejects_before_new_document(self):
+		with (
+			patch(
+				f"{MODULE}.frappe.db.get_values",
+				return_value=[
+					frappe._dict(
+						name="_Test Bank Transaction",
+						deposit=10,
+						withdrawal=0,
+						bank_account="_Test Bank Account",
+						currency="NZD",
+						unallocated_amount=10,
+					)
+				],
+			),
+			patch(f"{MODULE}.frappe.get_value", side_effect=["Bank - TC", "_Test Company"]),
+			patch(f"{MODULE}.frappe.db.get_value", return_value="Income"),
+			patch(f"{MODULE}.assert_party_access", side_effect=frappe.ValidationError),
+			patch(f"{MODULE}.frappe.new_doc") as new_doc,
+		):
+			with self.assertRaises(frappe.ValidationError):
+				create_journal_entry_bts(
+					"_Test Bank Transaction",
+					entry_type="Bank Entry",
+					second_account="Income - TC",
+					party_type="Customer",
+					party="_Test Customer",
+				)
+		new_doc.assert_not_called()
+
+	def test_payment_entry_rejects_before_party_account_lookup(self):
+		with (
+			patch(
+				f"{MODULE}.frappe.db.get_values",
+				return_value=[
+					frappe._dict(
+						name="_Test Bank Transaction",
+						deposit=10,
+						bank_account="_Test Bank Account",
+						currency="NZD",
+						unallocated_amount=10,
+					)
+				],
+			),
+			patch(f"{MODULE}.frappe.get_cached_value", side_effect=["Bank - TC", "_Test Company"]),
+			patch(f"{MODULE}.assert_party_access", side_effect=frappe.ValidationError),
+			patch("erpnext.accounts.party.get_party_account") as get_party_account,
+		):
+			with self.assertRaises(frappe.ValidationError):
+				create_payment_entry_bts(
+					"_Test Bank Transaction",
+					party_type="Supplier",
+					party="_Test Supplier",
+				)
+		get_party_account.assert_not_called()
+```
+
+Use one `frappe.get_cached_value` call for the Bank Account account, followed by one call for the Account company. The tests must assert the rejected call never reaches `frappe.new_doc` or `get_party_account`.
+
+- [ ] **Step 3: Add failing modern API and cash-coding tests**
+
+Extend `api/test_bank_rec.py` with focused mocks:
+
+```python
+	def test_update_metadata_passes_transaction_company_to_party_policy(self):
+		transaction = frappe._dict(
+			name="_Test Bank Transaction",
+			company="_Test Company",
+			status="Unreconciled",
+			reference_number="",
+			party_type="",
+			party="",
+		)
+		transaction.reload = lambda: None
+		transaction.save = lambda: None
+		transaction.as_dict = lambda: transaction
+		with (
+			patch(
+				"advanced_bank_reconciliation.api.matching.assert_bank_transaction_access",
+				return_value=transaction,
+			),
+			patch("advanced_bank_reconciliation.api.matching._lock_bank_transaction"),
+			patch("advanced_bank_reconciliation.api.matching.assert_party_access") as assert_party,
+		):
+			update_transaction_metadata(
+				transaction.name,
+				party_type="Customer",
+				party="_Test Customer",
+			)
+		assert_party.assert_called_once_with(
+			"Customer",
+			"_Test Customer",
+			company="_Test Company",
+		)
+
+	def test_create_voucher_passes_resolved_company_to_party_policy(self):
+		transaction = frappe._dict(name="_Test Bank Transaction")
+		payload = {"party_type": "Customer", "party": "_Test Customer"}
+		with (
+			patch("advanced_bank_reconciliation.api.create_voucher._get_company", return_value="_Test Company"),
+			patch("advanced_bank_reconciliation.api.create_voucher.assert_party_access") as assert_party,
+			patch("advanced_bank_reconciliation.api.create_voucher.create_payment_entry_bts", return_value=frappe._dict()),
+		):
+			_build_voucher(transaction, payload, allow_edit=True)
+		assert_party.assert_called_once_with(
+			"Customer",
+			"_Test Customer",
+			company="_Test Company",
+		)
+```
+
+For both cash-coding paths, use:
+
+```python
+	def _cash_coding_row(self):
+		return {
+			"bank_transaction_name": "_Test Bank Transaction",
+			"party_type": "Customer",
+			"party": "_Test Customer",
+			"account": "Income - TC",
+		}
+
+	def _cash_coding_transaction(self):
+		transaction = frappe._dict(
+			name="_Test Bank Transaction",
+			company="_Test Company",
+			bank_account="_Test Bank Account",
+			status="Unreconciled",
+			unallocated_amount=10,
+		)
+		transaction.reload = lambda: None
+		return transaction
+
+	def test_cash_coding_preview_passes_company_to_party_policy(self):
+		row = self._cash_coding_row()
+		transaction = self._cash_coding_transaction()
+		with (
+			patch(
+				"advanced_bank_reconciliation.api.cash_coding.assert_bank_transaction_access",
+				return_value=transaction,
+			),
+			patch("advanced_bank_reconciliation.api.cash_coding.assert_company_access"),
+			patch(
+				"advanced_bank_reconciliation.api.cash_coding.assert_party_access",
+				side_effect=frappe.ValidationError("Not available"),
+			) as assert_party,
+			patch("advanced_bank_reconciliation.api.cash_coding._assert_account") as assert_account,
+		):
+			result = preview_cash_coding([row])
+		self.assertEqual(result["results"][0]["status"], "error")
+		assert_party.assert_called_once_with(
+			"Customer",
+			"_Test Customer",
+			company="_Test Company",
+		)
+		assert_account.assert_not_called()
+
+	def test_cash_coding_submit_rejects_before_journal_entry(self):
+		row = self._cash_coding_row()
+		transaction = self._cash_coding_transaction()
+		with (
+			patch(
+				"advanced_bank_reconciliation.api.cash_coding.assert_bank_transaction_access",
+				return_value=transaction,
+			),
+			patch("advanced_bank_reconciliation.api.cash_coding._lock_bank_transaction"),
+			patch("advanced_bank_reconciliation.api.cash_coding.assert_company_access"),
+			patch(
+				"advanced_bank_reconciliation.api.cash_coding.assert_party_access",
+				side_effect=frappe.ValidationError("Not available"),
+			) as assert_party,
+			patch(
+				"advanced_bank_reconciliation.api.cash_coding.create_journal_entry_bts"
+			) as create_journal_entry,
+			patch(
+				"advanced_bank_reconciliation.api.cash_coding.get_abr_default_settings",
+				return_value={"default_journal_entry_type": "Bank Entry"},
+			),
+			patch("advanced_bank_reconciliation.api.cash_coding.frappe.db.savepoint"),
+			patch("advanced_bank_reconciliation.api.cash_coding.frappe.db.rollback"),
+		):
+			result = submit_cash_coding([row])
+		self.assertEqual(result["results"][0]["status"], "error")
+		assert_party.assert_called_once_with(
+			"Customer",
+			"_Test Customer",
+			company="_Test Company",
+		)
+		create_journal_entry.assert_not_called()
+```
+
+Import `preview_cash_coding`, `submit_cash_coding`, `_build_voucher`, and `update_transaction_metadata` into the test module alongside its existing API imports.
+
+- [ ] **Step 4: Run the new mutation tests and confirm they fail**
+
+Run:
+
+```bash
+bench --site demo.localhost run-tests --app advanced_bank_reconciliation --module advanced_bank_reconciliation.api.test_party_company
+bench --site demo.localhost run-tests --app advanced_bank_reconciliation --module advanced_bank_reconciliation.advanced_bank_reconciliation.doctype.advance_bank_reconciliation_tool.tests.test_party_company_enforcement
+bench --site demo.localhost run-tests --app advanced_bank_reconciliation --module advanced_bank_reconciliation.api.test_bank_rec
+```
+
+Expected: failures show that company is not yet passed to the policy.
+
+- [ ] **Step 5: Delegate `assert_party_access` to the shared policy**
+
+Change the signature:
+
+```python
+def assert_party_access(party_type=None, party=None, company=None, user=None):
+```
+
+Retain the existing supported-type and pairing validation. For a complete pair, call:
+
+```python
+return assert_party_eligible_for_company(
+	party_type,
+	party,
+	company,
+	user=user,
+)
+```
+
+Use `SUPPORTED_PARTY_TYPES` from `party_company.py` as the single allowlist source and keep `ALLOWED_PARTY_TYPES` as an alias only if unchanged callers or tests import it.
+
+- [ ] **Step 6: Enforce the policy in legacy mutations**
+
+For `update_bank_transaction`, load the Bank Transaction first and resolve:
+
+```python
+company = bank_transaction.company or frappe.get_cached_value(
+	"Bank Account",
+	bank_transaction.bank_account,
+	"company",
+)
+assert_party_access(party_type, party, company=company)
+```
+
+For both voucher helpers:
+
+1. Include `company` in the initial Bank Transaction field query when available.
+2. Otherwise derive it from the Bank Account or bank GL Account.
+3. Call `assert_party_access(party_type, party, company=company)` after company resolution and before party-account lookup, `frappe.new_doc`, or mutation.
+
+The helpers must continue accepting no party for Journal Entries on non-receivable/payable accounts. Payment Entry still requires a complete party pair through its existing business path.
+
+- [ ] **Step 7: Enforce the policy in modern mutations**
+
+Pass the resolved company in:
+
+```python
+assert_party_access(
+	common["party_type"],
+	common["party"],
+	company=company,
+)
+```
+
+Apply the same form to:
+
+- `matching.update_transaction_metadata`, using `transaction.company` or the Bank Account fallback.
+- `cash_coding.preview_cash_coding`, using the already resolved row company.
+- `cash_coding.submit_cash_coding`, using the already resolved row company.
+
+Voucher draft creation is covered because it uses `_build_voucher`.
+
+- [ ] **Step 8: Run Task 2 tests**
+
+Run:
+
+```bash
+bench --site demo.localhost run-tests --app advanced_bank_reconciliation --module advanced_bank_reconciliation.api.test_party_company
+bench --site demo.localhost run-tests --app advanced_bank_reconciliation --module advanced_bank_reconciliation.advanced_bank_reconciliation.doctype.advance_bank_reconciliation_tool.tests.test_party_company_enforcement
+bench --site demo.localhost run-tests --app advanced_bank_reconciliation --module advanced_bank_reconciliation.api.test_bank_rec
+```
+
+Expected: all focused mutation tests pass, including disabled-policy regressions already covered by existing API tests.
+
+- [ ] **Step 9: Commit Task 2**
+
+```bash
+git add advanced_bank_reconciliation/api/permission.py \
+  advanced_bank_reconciliation/api/create_voucher.py \
+  advanced_bank_reconciliation/api/matching.py \
+  advanced_bank_reconciliation/api/cash_coding.py \
+  advanced_bank_reconciliation/api/test_bank_rec.py \
+  advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool
+git commit -m "fix: enforce party company eligibility"
+```
+
+---
+
+### Task 3: Bank Rule and Legacy Desk Filtering
+
+**Files:**
+
+- Modify: `advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/abr_bank_rule/abr_bank_rule.py`
+- Modify: `advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/abr_bank_rule/abr_bank_rule.js`
+- Modify: `advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/abr_bank_rule/test_abr_bank_rule.py`
+- Modify: `advanced_bank_reconciliation/public/js/advance_bank_reconciliation_tool/dialog_manager.js`
+
+**Interfaces:**
+
+- Consumes:
+  - Search query path `advanced_bank_reconciliation.api.party_company.search_parties`
+  - `assert_party_access(party_type=None, party=None, company=None, user=None)`
+- Produces:
+  - Company-aware Dynamic Link queries on the legacy reconciliation dialog and ABR Bank Rule form.
+  - Bank Rule validation and execution that cannot bypass the shared policy.
+
+- [ ] **Step 1: Add failing Bank Rule validation and execution tests**
+
+Extend `test_abr_bank_rule.py`:
+
+```python
+	def test_rule_party_is_validated_for_rule_company(self):
+		rule = self._make_rule(
+			entry_type="Payment Entry",
+			account="",
+			party_type="Customer",
+			party="_Test Customer",
+		)
+		with patch(
+			f"{ABR_MODULE}.assert_party_access",
+			side_effect=frappe.ValidationError,
+		) as assert_party:
+			with self.assertRaises(frappe.ValidationError):
+				rule.insert()
+		assert_party.assert_called_once_with(
+			"Customer",
+			"_Test Customer",
+			company=TEST_COMPANY,
+		)
+```
+
+Add this `_execute_rule_action` test:
+
+```python
+	def test_rule_execution_revalidates_party_company(self):
+		transaction = frappe._dict(
+			name="_Test Bank Transaction",
+			company=TEST_COMPANY,
+			reference_number="",
+			date=today(),
+		)
+		rule = frappe._dict(
+			name="ABR-RULE-TEST",
+			title="Runtime Validation Rule",
+			entry_type="Payment Entry",
+			company=TEST_COMPANY,
+			party_type="Customer",
+			party="_Test Customer",
+			cost_center=None,
+			project=None,
+		)
+		with (
+			patch(f"{ABR_MODULE}._get_rule_dimensions", return_value={}),
+			patch(
+				f"{ABR_MODULE}.assert_party_access",
+				side_effect=frappe.ValidationError("Not available"),
+			) as assert_party,
+			patch(f"{ABR_MODULE}.create_payment_entry_bts") as create_payment_entry,
+		):
+			with self.assertRaises(frappe.ValidationError):
+				_execute_rule_action(transaction, rule, get_test_logger())
+		assert_party.assert_called_once_with(
+			"Customer",
+			"_Test Customer",
+			company=TEST_COMPANY,
+		)
+		create_payment_entry.assert_not_called()
+```
+
+Import `_execute_rule_action` from the Bank Rule controller. This runtime validation protects rules whose party metadata changed after save.
+
+- [ ] **Step 2: Run the Bank Rule tests and confirm failure**
+
+Run:
+
+```bash
+bench --site demo.localhost run-tests --app advanced_bank_reconciliation --module advanced_bank_reconciliation.advanced_bank_reconciliation.doctype.abr_bank_rule.test_abr_bank_rule
+```
+
+Expected: the new company-policy assertions fail.
+
+- [ ] **Step 3: Enforce Bank Rule policy**
+
+In `ABRBankRule.validate`, after required party checks:
+
+```python
+assert_party_access(
+	self.party_type,
+	self.party,
+	company=self.company,
+)
+```
+
+In `_execute_rule_action`, validate the party again before either Journal Entry or Payment Entry helper:
+
+```python
+assert_party_access(
+	rule.party_type,
+	rule.party,
+	company=transaction.company or rule.company,
+)
+```
+
+The voucher helpers remain a second enforcement layer.
+
+- [ ] **Step 4: Add the shared query to the legacy reconciliation dialog**
+
+Set the Party Dynamic Link query:
+
+```javascript
+get_query: () => ({
+	query: "advanced_bank_reconciliation.api.party_company.search_parties",
+	filters: {
+		party_type: this.dialog.get_value("party_type"),
+		company: this.company,
+	},
+}),
+```
+
+Add an `onchange` handler to Party Type:
+
+```javascript
+onchange: () => {
+	this.dialog.set_value("party", "");
+},
+```
+
+Limit the legacy Party Type choices to the three supported types instead of every `frappe.boot.party_account_types` key.
+
+- [ ] **Step 5: Add the shared query to the ABR Bank Rule form**
+
+In `refresh`:
+
+```javascript
+frm.set_query("party", () => ({
+	query: "advanced_bank_reconciliation.api.party_company.search_parties",
+	filters: {
+		party_type: frm.doc.party_type,
+		company: frm.doc.company,
+	},
+}));
+```
+
+Clear dependent values:
+
+```javascript
+company(frm) {
+	for (const field of ["bank_account", "account", "cost_center", "party"]) {
+		frm.set_value(field, "");
+	}
+},
+
+party_type(frm) {
+	frm.set_value("party", "");
+},
+```
+
+- [ ] **Step 6: Syntax-check JavaScript and run Bank Rule tests**
+
+Run:
+
+```bash
+node --check advanced_bank_reconciliation/public/js/advance_bank_reconciliation_tool/dialog_manager.js
+node --check advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/abr_bank_rule/abr_bank_rule.js
+bench --site demo.localhost run-tests --app advanced_bank_reconciliation --module advanced_bank_reconciliation.advanced_bank_reconciliation.doctype.abr_bank_rule.test_abr_bank_rule
+```
+
+Expected: syntax checks succeed and all Bank Rule tests pass.
+
+- [ ] **Step 7: Commit Task 3**
+
+```bash
+git add advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/abr_bank_rule \
+  advanced_bank_reconciliation/public/js/advance_bank_reconciliation_tool/dialog_manager.js
+git commit -m "fix: filter parties in desk workflows"
+```
+
+---
+
+### Task 4: Modern Bank Rec Party Autocomplete
+
+**Files:**
+
+- Create: `bank_rec/src/components/PartyAutocomplete.vue`
+- Modify: `bank_rec/src/services/api.ts`
+- Modify: `bank_rec/src/types/bankRec.ts`
+- Modify: `bank_rec/src/components/CreateVoucherPanel.vue`
+- Modify: `bank_rec/src/components/UpdateTransactionPanel.vue`
+- Modify: `bank_rec/src/pages/CashCodingPage.vue`
+
+**Interfaces:**
+
+- Consumes:
+  - `search_parties(doctype, txt, searchfield, start, page_len, filters)`
+- Produces:
+  - `PartySearchResult { value: string; label: string }`
+  - `searchParties(params: { party_type: string; company: string; txt?: string; page_len?: number }): Promise<PartySearchResult[]>`
+  - Reusable `PartyAutocomplete` with props `company`, `partyType`, `modelValue`, `label?`, `placeholder?`, and `disabled?`.
+
+- [ ] **Step 1: Add the typed search service**
+
+Add:
+
+```typescript
+export interface PartySearchResult {
+  value: string;
+  label: string;
+}
+```
+
+In `api.ts`, add:
+
+```typescript
+const partyCompanyApiPath =
+  "/api/method/advanced_bank_reconciliation.api.party_company.";
+
+export async function searchParties(params: {
+  party_type: string;
+  company: string;
+  txt?: string;
+  page_len?: number;
+}) {
+  const rows = await call<string[][]>(partyCompanyApiPath, "search_parties", {
+    doctype: params.party_type,
+    txt: params.txt || "",
+    searchfield: "name",
+    start: 0,
+    page_len: params.page_len || 20,
+    filters: {
+      party_type: params.party_type,
+      company: params.company,
+    },
+  });
+  return rows.map((row) => ({
+    value: row[0],
+    label: row[1] && row[1] !== row[0] ? `${row[1]} (${row[0]})` : row[0],
+  }));
+}
+```
+
+- [ ] **Step 2: Implement the reusable component**
+
+`PartyAutocomplete.vue` must:
+
+- Render a label when supplied, an input, a loading indicator, an error message, and a positioned result list.
+- Debounce input searches by 250 ms.
+- Ignore stale responses using an incrementing request id.
+- Use `company`, `partyType`, and typed text in `searchParties`.
+- Emit typed input as `modelValue` so direct submissions remain possible, and replace it with the selected result `value` when a result is chosen. The server remains authoritative for typed values not selected from the list.
+- Close on blur after selection can complete.
+- When company or Party Type changes, search the current value and retain it only if an exact result remains; otherwise emit `update:modelValue` with `""`.
+- Clear results and emit `""` when Party Type or company is blank.
+- Cancel the debounce timer in `onBeforeUnmount`.
+
+Use this public shape:
+
+```typescript
+const props = withDefaults(
+  defineProps<{
+    company: string;
+    partyType: string;
+    modelValue: string;
+    label?: string;
+    placeholder?: string;
+    disabled?: boolean;
+  }>(),
+  {
+    label: "",
+    placeholder: "Search parties",
+    disabled: false,
+  }
+);
+
+const emit = defineEmits<{
+  "update:modelValue": [value: string];
+}>();
+```
+
+Use semantic buttons for results and the existing Bank Rec border, focus, muted, and error utility classes.
+
+- [ ] **Step 3: Replace Create and Update free-text fields**
+
+In `CreateVoucherPanel.vue`:
+
+```vue
+<PartyAutocomplete
+  v-model="party"
+  :company="defaults.bank_account.company"
+  :party-type="partyType"
+  :label="contactLabel"
+/>
+```
+
+In `UpdateTransactionPanel.vue`:
+
+```vue
+<PartyAutocomplete
+  v-model="party"
+  :company="transaction.company || ''"
+  :party-type="partyType"
+  label="Party"
+/>
+```
+
+Import the component in both files. Keep existing payload and dirty-state behavior.
+
+- [ ] **Step 4: Replace Cash Coding free-text fields**
+
+Replace only the party text input with:
+
+```vue
+<PartyAutocomplete
+  v-model="row.party"
+  :company="row.transaction.company || store.selectedCompany"
+  :party-type="row.party_type"
+  placeholder="Party"
+  @update:model-value="markDirty(row.transaction.name)"
+/>
+```
+
+On Party Type change, clear `row.party` before marking the row dirty so a party from the previous DocType is never submitted.
+
+- [ ] **Step 5: Build the modern frontend**
+
+Run:
+
+```bash
+yarn --cwd bank_rec build
+```
+
+Expected: TypeScript and Vite build succeed with no errors.
+
+- [ ] **Step 6: Verify all three modern call sites**
+
+Use source checks:
+
+```bash
+rg -n "<PartyAutocomplete" \
+  bank_rec/src/components/CreateVoucherPanel.vue \
+  bank_rec/src/components/UpdateTransactionPanel.vue \
+  bank_rec/src/pages/CashCodingPage.vue
+rg -n 'v-model="party"|v-model="row.party"' \
+  bank_rec/src/components/CreateVoucherPanel.vue \
+  bank_rec/src/components/UpdateTransactionPanel.vue \
+  bank_rec/src/pages/CashCodingPage.vue
+```
+
+Expected: exactly one `PartyAutocomplete` use at each target and no remaining free-text party input.
+
+- [ ] **Step 7: Commit Task 4**
+
+```bash
+git add bank_rec/src
+git commit -m "fix: filter parties in bank rec frontend"
+```
+
+---
+
+### Task 5: Cross-Workflow Regression and Release Verification
+
+**Files:**
+
+- Modify only if a regression is found in a file already owned by Tasks 1 to 4.
+
+**Interfaces:**
+
+- Consumes all prior task outputs.
+- Produces test evidence for server policy, mutations, rules, legacy JavaScript, and the modern production build.
+
+- [ ] **Step 1: Run the complete app test suite**
+
+Run:
+
+```bash
+bench --site demo.localhost run-tests --app advanced_bank_reconciliation
+```
+
+Expected: all app tests pass.
+
+- [ ] **Step 2: Run static and frontend verification**
+
+Run:
+
+```bash
+pre-commit run --all-files
+node --check advanced_bank_reconciliation/public/js/advance_bank_reconciliation_tool/dialog_manager.js
+node --check advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/abr_bank_rule/abr_bank_rule.js
+yarn --cwd bank_rec build
+```
+
+Expected: every command succeeds.
+
+- [ ] **Step 3: Verify configuration and policy behavior on the local site**
+
+Using `bench --site demo.localhost console`, create generic test parties. If Customer or Supplier has no safe generic ownership field, create a temporary `company_scope` Custom Field with `fieldtype = "Link"` and `options = "Company"`, use it for this verification, then delete that Custom Field after restoring the settings to disabled. Verify:
+
+1. Filtering disabled returns a permitted global party.
+2. Filtering enabled with exact-company mapping returns and accepts the party.
+3. A blank mapped company returns and accepts the party as shared.
+4. A different mapped company does not return the party and rejects direct mutation.
+5. Missing mapping fails closed.
+6. An enabled incompatible ABR Bank Rule blocks settings activation.
+
+Roll back the console transaction or delete only the generic test records created for this verification.
+
+- [ ] **Step 4: Browser-check the four user-facing workflows**
+
+On `demo.localhost`:
+
+1. Open Advance Bank Reconciliation Settings and confirm each mapping Autocomplete shows only Company Link fields with label and fieldname.
+2. Open legacy Bank Reconciliation, change Party Type, and confirm Party clears and searches only exact-company/shared records.
+3. Open an ABR Bank Rule, change Company or Party Type, and confirm Party clears and uses the same filtered search.
+4. Open modern Create, Update, and Cash Coding screens, type a party query, and confirm only exact-company/shared results render.
+5. Confirm no new browser console errors.
+
+- [ ] **Step 5: Scan the branch for public-data safety and scope**
+
+Run:
+
+```bash
+git diff --check main...HEAD
+git diff --name-only main...HEAD
+```
+
+Run the required customer-identifier scan using the private pattern list held outside this public repository. Do not copy those identifiers into a tracked file, commit message, PR title, or PR body.
+
+Expected: no whitespace errors, only intended files, and no customer-specific matches.
+
+- [ ] **Step 6: Commit any verification-only fixes**
+
+If Tasks 1 to 4 required a correction, stage only the corrected implementation and covering test, then commit:
+
+```bash
+git commit -m "fix: complete party company filtering safeguards"
+```
+
+If no correction was needed, do not create an empty commit.
+
+- [ ] **Step 7: Prepare a merge-ready pull request**
+
+Before creating the PR:
+
+```bash
+git status --short
+git log --oneline main..HEAD
+git diff --stat main...HEAD
+```
+
+Scan the full diff and proposed PR text with the private safety pattern list before pushing. Push the branch and create a PR with a generic `fix:` title. The description must include behavior, configuration defaults, test evidence, risk, and rollout steps without customer-specific context. Do not merge it.

--- a/docs/superpowers/specs/2026-07-25-party-company-filter-design.md
+++ b/docs/superpowers/specs/2026-07-25-party-company-filter-design.md
@@ -1,0 +1,314 @@
+# Configurable Party Company Filtering
+
+## Summary
+
+Advanced Bank Reconciliation currently treats Customer, Supplier, and Employee
+as global parties. On a multi-company site, a user can therefore select a party
+associated with a different company while reconciling a bank account.
+
+This change adds an optional company filter for parties. Each site explicitly
+maps Customer, Supplier, and Employee to the Link field that represents the
+party's owning company. Advanced Bank Reconciliation then uses that mapping for
+party searches and server-side validation.
+
+The feature is disabled by default. Enabling it does not modify historical
+documents.
+
+## Goals
+
+- Prevent a party associated with another company from being selected or
+  submitted in bank reconciliation workflows.
+- Treat a blank party company as shared and eligible for every company.
+- Support custom Company Link fieldnames without hard-coding site-specific
+  metadata in the shared app.
+- Preserve current behavior when filtering is disabled.
+- Apply one authoritative eligibility rule to legacy and modern interfaces,
+  direct API calls, and automated bank rules.
+
+## Non-goals
+
+- Assigning parties to more than one specific company.
+- Migrating or populating party company fields.
+- Modifying historical Bank Transactions, Journal Entries, Payment Entries, or
+  ABR Bank Rules.
+- Inferring business meaning from a field label or fieldname.
+- Supporting party doctypes other than Customer, Supplier, and Employee.
+
+## Approaches Considered
+
+### Automatic Company Link discovery
+
+The app could select the first or only Link field whose target is Company.
+This is unsafe because Customer and Supplier already contain
+`represents_company`, which describes an internal trading relationship rather
+than ownership or availability.
+
+### Explicit fields in ABR Settings
+
+Add one mapping field for each supported Party Type. Metadata supplies the
+available choices and validates the saved value. This is the selected approach.
+The supported Party Types are already a fixed allowlist, so three settings are
+clearer and smaller than a new mapping child table.
+
+### Mapping child table
+
+A child table would be more extensible if arbitrary Party Types were supported.
+It adds another DocType, grid behavior, duplicate-row validation, and dynamic
+field options without providing a current benefit.
+
+## Settings
+
+Add a **Party Company Filtering** section to the Single DocType
+`Advance Bank Reconciliation Settings`.
+
+Fields:
+
+| Fieldname | Type | Default | Behavior |
+| --- | --- | --- | --- |
+| `filter_parties_by_company` | Check | `0` | Enables party filtering and validation |
+| `customer_company_field` | Autocomplete | blank | Customer Link field that represents owning company |
+| `supplier_company_field` | Autocomplete | blank | Supplier Link field that represents owning company |
+| `employee_company_field` | Autocomplete | `company` | Employee Link field that represents owning company |
+
+The three mapping fields are visible and mandatory only when filtering is
+enabled. Their autocomplete choices come from server-validated DocType metadata
+and include only fields where:
+
+- `fieldtype` is `Link`
+- `options` is `Company`
+
+The UI displays both label and fieldname so administrators can distinguish
+similarly named fields. Customer and Supplier mappings are intentionally not
+defaulted. In particular, the app must not assume `represents_company` is an
+ownership field.
+
+When filtering is enabled, settings validation requires all three mappings.
+Each mapping must still exist and remain a Link to Company. Invalid, deleted, or
+renamed fields produce an actionable validation error.
+
+Saving an enabled configuration checks enabled ABR Bank Rules that contain a
+party. If an enabled rule's party is not eligible for the rule company, saving
+is rejected with a bounded list of affected rules. The administrator must
+correct or disable those rules before activation.
+
+## Party Eligibility
+
+For a selected reconciliation company and a configured Party Type:
+
+| Party company value | Result |
+| --- | --- |
+| Selected company | Eligible |
+| Blank or null | Eligible as shared |
+| Another company | Ineligible |
+
+Existing read permissions, select permissions, disabled-party behavior, and
+standard Frappe search behavior remain in force.
+
+If filtering is enabled but configuration is missing or invalid at runtime,
+the operation fails with a configuration error. It must not silently return an
+unfiltered list.
+
+## Server Architecture
+
+Create a focused module:
+
+`advanced_bank_reconciliation/api/party_company.py`
+
+It owns configuration resolution, metadata validation, party search, and
+company eligibility.
+
+Public interfaces:
+
+```python
+SUPPORTED_PARTY_TYPES = ("Customer", "Supplier", "Employee")
+
+def get_company_link_fields(party_type: str) -> list[dict]:
+    """Return valid Company Link fields as fieldname and label records."""
+
+def get_party_company_field(
+    party_type: str,
+    settings=None,
+) -> str | None:
+    """Return the configured field, or None when filtering is disabled."""
+
+def is_party_eligible_for_company(
+    party_type: str,
+    party: str,
+    company: str,
+    settings=None,
+) -> bool:
+    """Return whether the party is exact-company or shared."""
+
+def assert_party_eligible_for_company(
+    party_type: str,
+    party: str,
+    company: str,
+    user: str | None = None,
+    settings=None,
+):
+    """Check party validity, read access, and optional company eligibility."""
+
+@frappe.whitelist()
+@frappe.validate_and_sanitize_search_inputs
+def search_parties(
+    doctype,
+    txt,
+    searchfield,
+    start,
+    page_len,
+    filters,
+):
+    """Return permitted party matches for the supplied company."""
+```
+
+The search method validates the Party Type allowlist, Company access, configured
+metadata, search inputs, and user permissions. When filtering is enabled it
+adds an exact-company-or-blank condition. When disabled it preserves standard
+global search behavior.
+
+Settings and DocType metadata may use Frappe's normal document and metadata
+caches. Search results are not cached because permissions and search text vary
+per request.
+
+`assert_party_access` in `api/permission.py` gains a `company` argument and
+delegates company eligibility to the shared module. When filtering is enabled
+and a party is supplied, company is mandatory.
+
+## Mutation Coverage
+
+Every path that writes or acts on a party must supply the company:
+
+- Legacy `update_bank_transaction`
+- Legacy `create_journal_entry_bts`
+- Legacy `create_payment_entry_bts`
+- Modern `update_transaction_metadata`
+- Modern voucher creation and draft creation
+- Cash-coding preview and submission
+- ABR Bank Rule validation
+- ABR Bank Rule action execution
+
+Legacy voucher methods derive company from the Bank Transaction's Bank Account
+before validating the party. Modern methods use the company already resolved
+through their Bank Transaction access checks.
+
+ABR Bank Rule validation checks the configured party against the rule company.
+Rule execution validates again through the voucher method so a later metadata
+or party change cannot bypass the rule.
+
+## Legacy Interface
+
+The legacy reconciliation dialog's Party Dynamic Link uses `search_parties`
+with the selected Bank Account company. Party Type changes clear the existing
+Party value.
+
+The ABR Bank Rule form uses the same query with the rule company and Party Type.
+Changing either controlling value clears the Party value.
+
+If filtering is disabled, the query returns the same globally permitted parties
+as the current Link search.
+
+## Modern Interface
+
+Add a reusable `PartyAutocomplete` component to the modern Bank Rec frontend.
+It accepts:
+
+- `company`
+- `partyType`
+- `modelValue`
+- disabled and label presentation properties
+
+The component performs a debounced search through `search_parties`, renders
+permitted results, and emits the selected party name. It clears its value when
+Company or Party Type changes and the current value is no longer valid.
+
+Use the component in:
+
+- Create Voucher
+- Update Bank Transaction
+- Cash Coding
+
+The server remains authoritative if a user types or submits a value that is not
+in the suggestions.
+
+## Errors
+
+Errors must identify the action the administrator or user can take:
+
+- Filtering enabled with a missing mapping:
+  `Configure the Customer Company Field in Advance Bank Reconciliation Settings.`
+- Mapping does not resolve to a Company Link:
+  `Field <fieldname> on <doctype> must be a Link to Company.`
+- Party belongs to another company:
+  `<party_type> <party> is not available for company <company>.`
+- Missing company during an enabled validation:
+  `Company is required when party company filtering is enabled.`
+
+Messages must not expose records that the current user cannot read.
+
+## Backward Compatibility
+
+- The setting defaults to disabled.
+- Disabled behavior remains global and matches the current implementation.
+- Migration only adds settings fields and frontend/server behavior.
+- Existing documents and rules are not rewritten.
+- Enabling is blocked until mappings and enabled rules are valid.
+- Disabling restores current global party behavior.
+
+## Test Strategy
+
+Use Frappe v15 `FrappeTestCase` and generic test records.
+
+### Settings and metadata
+
+- Disabled setting permits blank mappings.
+- Enabled setting requires all mappings.
+- Valid Link-to-Company mappings save.
+- Missing fields, non-Link fields, and Links to another DocType are rejected.
+- Metadata candidate API returns only Links to Company.
+- Customer and Supplier mappings are not automatically assigned.
+
+### Eligibility and search
+
+For Customer, Supplier, and Employee:
+
+- Exact-company party is returned and accepted.
+- Blank-company party is returned and accepted.
+- Other-company party is neither returned nor accepted.
+- Filtering disabled returns current permitted results.
+- Unsupported Party Types are rejected.
+- Missing or stale configuration fails closed.
+- User permissions remain effective.
+
+### Mutation paths
+
+- Bank Transaction metadata update rejects an ineligible party.
+- Journal Entry creation rejects an ineligible reference party.
+- Payment Entry creation rejects an ineligible accounting party.
+- Voucher draft creation rejects an ineligible party.
+- Cash-coding preview and submission reject an ineligible party.
+- Eligible and shared parties continue to work.
+
+### Bank rules
+
+- Rule validation rejects an ineligible party.
+- Enabling settings detects incompatible enabled rules.
+- Rule execution cannot bypass validation after configuration or party changes.
+
+### Frontend verification
+
+- Legacy Party search sends Party Type and company.
+- Party is cleared when its controlling values change.
+- Modern frontend production build succeeds.
+- Browser checks cover Create, Update, Cash Coding, and Bank Rule party searches.
+- Browser console contains no new errors.
+
+## Rollout
+
+1. Deploy the patch with filtering disabled.
+2. Ensure each supported Party Type has a populated ownership Company field.
+3. Configure the three mappings.
+4. Review any incompatible enabled bank rules.
+5. Enable filtering.
+6. Validate exact-company and shared party searches in Bank Rec.
+
+No production configuration or deployment is part of this pull request.


### PR DESCRIPTION
## Summary

- add optional Company Link mappings for Customer, Supplier, and Employee
- treat blank mapped company values as shared and exact matches as company-specific
- enforce the policy across party search, legacy and modern reconciliation flows, cash coding, direct mutations, and bank rules
- preserve existing global party behavior while the setting is disabled
- validate mappings and enabled rules before activation

## Verification

- 254 backend tests run, 252 passed and 2 skipped
- focused RPC override and contextual-permission regressions passed
- legacy Desk JavaScript syntax checks passed
- production frontend build passed
- final scoped review found no remaining Critical, Important, or Minor issues

## Rollout

The feature is disabled by default. Configure valid Company Link fields in Advance Bank Reconciliation Settings, then enable party filtering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable party-by-company filtering for Customers, Suppliers and Employees in reconciliation settings.
  * Introduced company-aware party search with debounced autocomplete across voucher creation, transaction updates and cash coding workflows.
* **Bug Fixes**
  * Improved permission enforcement by validating party access against the effective company before saving or creating journal/payment entries.
  * ABR Bank Rule now filters party results by party type and company, and clears dependent fields when company changes.
* **Documentation**
  * Added design and implementation guidance for party-company filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->