### PR TITLE
fix: import numeric bank references as text

### DIFF
--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/bank_statement_importer/bank_statement_importer.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/bank_statement_importer/bank_statement_importer.py
@@ -575,7 +575,7 @@ def publish_records(data_import, importer_data=None):
                 "currency": item[6],
                 "deposit": item[1],
                 "withdrawal": item[2],
-                "reference_number": item[4],
+                "reference_number": str(item[4]) if item[4] is not None else None,
                 "description": str(item[3]) if item[3] else None,
             }
 

--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/bank_statement_importer/test_bank_statement_importer.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/bank_statement_importer/test_bank_statement_importer.py
@@ -1,7 +1,9 @@
 # Copyright (c) 2024, High Flyer and Contributors
 # See license.txt
 
+import json
 from datetime import date
+from unittest.mock import patch
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
@@ -12,10 +14,57 @@ from advanced_bank_reconciliation.advanced_bank_reconciliation.doctype.bank_stat
     normalize_mapping_for_headers,
     parse_date,
     parse_json_if_required,
+    publish_records,
 )
 
 
 class TestBankStatementImporter(FrappeTestCase):
+    def test_publish_records_converts_numeric_reference_to_text(self):
+        class FakeBankTransaction:
+            def update(self, values):
+                self.__dict__.update(values)
+
+            def insert(self):
+                pass
+
+            def submit(self):
+                pass
+
+        transaction = FakeBankTransaction()
+        dataset = [
+            [
+                "Date",
+                "Deposit",
+                "Withdrawal",
+                "Description",
+                "Reference Number",
+                "Bank Account",
+                "Currency",
+                "Is Duplicated",
+            ],
+            [
+                "2026-08-01",
+                100,
+                0,
+                "Deposit",
+                123,
+                "_Test Bank Account",
+                "NZD",
+                0,
+            ],
+        ]
+
+        with (
+            patch.object(frappe, "new_doc", return_value=transaction),
+            patch(
+                "advanced_bank_reconciliation.advanced_bank_reconciliation.doctype.bank_statement_importer.bank_statement_importer.flip_amount_for_credit_card"
+            ),
+        ):
+            success = publish_records(json.dumps(dataset))
+
+        self.assertTrue(success)
+        self.assertEqual(transaction.reference_number, "123")
+
     def test_date_parser(self):
         expected_date = date(2024, 5, 9)
 


### PR DESCRIPTION
## Summary

- convert numeric bank statement Reference values to text before creating Bank Transactions
- preserve null and existing text reference values
- add regression coverage for numeric-only spreadsheet references

## Testing

- Bank Statement Importer focused module: 7 tests passed
- Existing statement-importer integration coverage: 5 tests passed
- git diff --check

## Release

Patch release via the repository's configured semantic-release rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bank transaction reference numbers are now handled consistently when imported from numeric data.
  * Missing reference numbers remain blank instead of being incorrectly converted.

* **Tests**
  * Added regression coverage to verify successful processing of numeric reference numbers during bank statement imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->