### PR TITLE
fix: make bank rec navbar logo configurable

### DIFF
--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_settings/advance_bank_reconciliation_settings.json
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_settings/advance_bank_reconciliation_settings.json
@@ -5,6 +5,8 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "appearance_section",
+  "navbar_logo",
   "default_actions_section",
   "default_reconciliation_action",
   "default_document_type",
@@ -23,6 +25,17 @@
   "reconcile_unpaid_invoices_in_background"
  ],
  "fields": [
+  {
+   "fieldname": "appearance_section",
+   "fieldtype": "Section Break",
+   "label": "Appearance"
+  },
+  {
+   "description": "Shown in the modern Bank Rec navbar. The default icon is used when blank.",
+   "fieldname": "navbar_logo",
+   "fieldtype": "Attach Image",
+   "label": "Navbar Logo"
+  },
   {
    "fieldname": "default_actions_section",
    "fieldtype": "Section Break",
@@ -138,7 +151,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-07-25 09:38:24.000000",
+ "modified": "2026-08-06 19:58:13.000000",
  "modified_by": "Administrator",
  "module": "Advanced Bank Reconciliation",
  "name": "Advance Bank Reconciliation Settings",

--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_settings/test_advance_bank_reconciliation_settings.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_settings/test_advance_bank_reconciliation_settings.py
@@ -11,6 +11,9 @@ from advanced_bank_reconciliation.api.party_company import (
 	validate_enabled_bank_rules,
 	validate_party_company_settings,
 )
+from advanced_bank_reconciliation.advanced_bank_reconciliation.doctype.advance_bank_reconciliation_tool.advance_bank_reconciliation_tool import (
+	get_abr_default_settings,
+)
 
 
 def field(fieldname, fieldtype="Link", options="Company", label=None):
@@ -23,6 +26,19 @@ def field(fieldname, fieldtype="Link", options="Company", label=None):
 
 
 class TestAdvanceBankReconciliationSettings(FrappeTestCase):
+	def test_default_settings_include_configured_navbar_logo(self):
+		settings = frappe._dict(
+			default_reconciliation_action="Match Against Voucher",
+			default_document_type="Payment Entry",
+			default_journal_entry_type="Bank Entry",
+			compact_matching_vouchers_table=0,
+			navbar_logo="/files/bank-rec-logo.svg",
+		)
+		with patch("frappe.get_single", return_value=settings):
+			default_settings = get_abr_default_settings()
+
+		self.assertEqual(default_settings["navbar_logo"], "/files/bank-rec-logo.svg")
+
 	def test_disabled_settings_allow_blank_mappings(self):
 		settings = frappe._dict(filter_parties_by_company=0)
 		validate_party_company_settings(settings)

--- a/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/advance_bank_reconciliation_tool.py
+++ b/advanced_bank_reconciliation/advanced_bank_reconciliation/doctype/advance_bank_reconciliation_tool/advance_bank_reconciliation_tool.py
@@ -194,6 +194,7 @@ def get_abr_default_settings():
 		"default_document_type": settings.default_document_type or "Payment Entry",
 		"default_journal_entry_type": settings.default_journal_entry_type or "Bank Entry",
 		"compact_matching_vouchers_table": bool(settings.compact_matching_vouchers_table),
+		"navbar_logo": settings.get("navbar_logo") or "",
 	}
 
 

--- a/bank_rec/src/components/AppShell.vue
+++ b/bank_rec/src/components/AppShell.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { RouterLink, RouterView, useRoute } from "vue-router";
+import { useBankRecStore } from "@/stores/bankRec";
 import CheckCheck from "~icons/lucide/check-check";
 import CheckCircle2 from "~icons/lucide/check-circle-2";
 import FileCheck2 from "~icons/lucide/file-check-2";
@@ -8,6 +9,7 @@ import ListChecks from "~icons/lucide/list-checks";
 import Table2 from "~icons/lucide/table-2";
 
 const route = useRoute();
+const store = useBankRecStore();
 
 function isActive(to: string) {
   return route.path === to || route.path.startsWith(`${to}/`);
@@ -37,6 +39,10 @@ const navItems = [
 ];
 
 const activeTitle = computed(() => route.name?.toString() || "Reconcile");
+const navbarLogo = computed(() => {
+  const logo = store.boot?.settings.navbar_logo ?? window.settings?.navbar_logo;
+  return typeof logo === "string" ? logo : "";
+});
 </script>
 
 <template>
@@ -48,7 +54,14 @@ const activeTitle = computed(() => route.name?.toString() || "Reconcile");
         class="mx-auto flex min-h-[64px] w-full max-w-[1920px] flex-col gap-3 px-4 py-3 md:flex-row md:items-center md:justify-between md:px-6 2xl:px-8"
       >
         <div class="flex min-w-0 items-center gap-3">
+          <img
+            v-if="navbarLogo"
+            :src="navbarLogo"
+            alt="Bank Rec logo"
+            class="h-8 w-auto max-w-[120px] shrink-0 object-contain sm:max-w-[160px]"
+          />
           <div
+            v-else
             class="flex h-8 w-8 shrink-0 items-center justify-center rounded-[9px] bg-gradient-to-br from-[#67E8F9] via-[#0891B2] to-[#155E75] text-white shadow-sm"
           >
             <CheckCheck class="h-5 w-5" />


### PR DESCRIPTION
## Summary

- add a Navbar Logo image setting for the modern Bank Rec UI
- expose the configured logo through the existing boot settings payload
- display the logo responsively while retaining the current icon as the fallback

## Verification

- focused settings module: 9 tests passed
- Vue production build: passed
- Ruff checks on changed Python surfaces: passed
- DocType JSON validation and diff checks: passed

## Notes

The standard local test bootstrap is currently blocked by unrelated stale test metadata for Bin Putaway Worksheet. The focused module passed with the existing fixture hook bypass, and CI will run the repository test workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Appearance setting to configure a custom logo for the bank reconciliation navigation bar.
  * The configured logo is displayed in the application header when available.
  * If no custom logo is configured, the existing default header icon remains visible.

* **Tests**
  * Added coverage to verify that the configured navigation logo is correctly applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->