### PR TITLE
ci: allow manual release dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- retain automatic releases on pushes to main
- allow authorized maintainers to run the release workflow manually

## Verification
- parsed the workflow YAML and verified both triggers
- passed git diff whitespace checks
- completed an independent workflow review with no findings

Application tests were not rerun because this changes only the workflow trigger.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added the ability to start the release process manually, in addition to automatic runs after changes are pushed to the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->