### PR TITLE
fix(bank-rec): create payment entries for unpaid invoice matches

### DIFF
--- a/advanced_bank_reconciliation/api/matching.py
+++ b/advanced_bank_reconciliation/api/matching.py
@@ -5,6 +5,7 @@ from frappe import _
 from frappe.utils import add_days, flt, getdate
 
 from advanced_bank_reconciliation.advanced_bank_reconciliation.doctype.advance_bank_reconciliation_tool.advance_bank_reconciliation_tool import (
+	create_payment_entries_for_invoices,
 	get_linked_payments,
 	reconcile_vouchers,
 )
@@ -26,6 +27,12 @@ DEFAULT_MATCH_DOCUMENT_TYPES = [
 	"unpaid_sales_invoice",
 	"unpaid_purchase_invoice",
 ]
+
+UNPAID_INVOICE_SOURCE_TYPES = {
+	"Unpaid Sales Invoice": "Sales Invoice",
+	"Unpaid Purchase Invoice": "Purchase Invoice",
+}
+
 
 def as_bool(value):
 	if isinstance(value, bool):
@@ -124,6 +131,7 @@ def _normalise_vouchers(vouchers):
 	normalised = []
 	for row in vouchers:
 		voucher_type = row.get("voucher_type") or row.get("payment_doctype")
+		source_type = row.get("source_type") or voucher_type
 		voucher_type = _normalise_voucher_type(voucher_type)
 		voucher_name = row.get("voucher_name") or row.get("payment_name")
 		amount = flt(row.get("amount"))
@@ -132,24 +140,99 @@ def _normalise_vouchers(vouchers):
 			frappe.throw(_("Each selected match must include a voucher type and name."))
 		if amount <= 0:
 			frappe.throw(_("Each selected match must include a positive amount."))
+		if (
+			source_type in UNPAID_INVOICE_SOURCE_TYPES
+			and UNPAID_INVOICE_SOURCE_TYPES[source_type] != voucher_type
+		):
+			frappe.throw(_("The selected invoice type does not match its source type."))
 
 		normalised.append(
 			{
 				"payment_doctype": voucher_type,
 				"payment_name": voucher_name,
 				"amount": amount,
+				"source_type": source_type,
 			}
 		)
 
 	return normalised
 
 
-def _existing_payment_keys(transaction):
-	return {
+def _existing_match_keys(transaction):
+	keys = {
 		(row.payment_document, row.payment_entry)
 		for row in transaction.get("payment_entries", [])
 		if row.payment_document and row.payment_entry
 	}
+	payment_entries = [
+		row.payment_entry
+		for row in transaction.get("payment_entries", [])
+		if row.payment_document == "Payment Entry" and row.payment_entry
+	]
+	if payment_entries:
+		keys.update(
+			(
+				row.reference_doctype,
+				row.reference_name,
+			)
+			for row in frappe.get_all(
+				"Payment Entry Reference",
+				filters={"parent": ["in", payment_entries]},
+				fields=["reference_doctype", "reference_name"],
+			)
+			if row.reference_doctype and row.reference_name
+		)
+	return keys
+
+
+def _prepare_reconciliation_vouchers(transaction, vouchers):
+	unpaid_invoices = []
+	regular_vouchers = []
+
+	for row in vouchers:
+		voucher_doc = assert_voucher_access(
+			row["payment_doctype"],
+			row["payment_name"],
+		)
+		source_type = row["source_type"]
+		outstanding_amount = flt(voucher_doc.get("outstanding_amount"))
+
+		if source_type not in UNPAID_INVOICE_SOURCE_TYPES:
+			regular_vouchers.append(
+				{
+					"payment_doctype": row["payment_doctype"],
+					"payment_name": row["payment_name"],
+					"amount": row["amount"],
+				}
+			)
+			continue
+
+		if not outstanding_amount:
+			frappe.throw(
+				_("Invoice {0} no longer has an outstanding amount.").format(
+					voucher_doc.name
+				)
+			)
+		allocated_amount = abs(flt(row["amount"]))
+		if outstanding_amount < 0:
+			allocated_amount *= -1
+		unpaid_invoices.append(
+			{
+				"doctype": source_type,
+				"name": row["payment_name"],
+				"allocated_amount": allocated_amount,
+			}
+		)
+
+	if unpaid_invoices:
+		created = create_payment_entries_for_invoices(
+			transaction.name,
+			unpaid_invoices,
+			auto_reconcile=False,
+		)
+		regular_vouchers = created["vouchers"] + regular_vouchers
+
+	return regular_vouchers
 
 
 def _linked_payment_dto(transaction):
@@ -229,7 +312,7 @@ def _submit_match(bank_transaction_name, vouchers):
 			(row["payment_doctype"], row["payment_name"])
 			for row in requested_vouchers
 		}
-		if requested_keys.issubset(_existing_payment_keys(transaction)):
+		if requested_keys.issubset(_existing_match_keys(transaction)):
 			return {
 				"status": transaction.status,
 				"idempotent": True,
@@ -239,7 +322,7 @@ def _submit_match(bank_transaction_name, vouchers):
 		frappe.throw(_("This bank transaction is already reconciled."))
 
 	normalised_vouchers = _normalise_vouchers(vouchers)
-	existing_keys = _existing_payment_keys(transaction)
+	existing_keys = _existing_match_keys(transaction)
 	requested_keys = {
 		(row["payment_doctype"], row["payment_name"])
 		for row in normalised_vouchers
@@ -251,10 +334,14 @@ def _submit_match(bank_transaction_name, vouchers):
 	if total - abs(flt(transaction.unallocated_amount)) > 0.01:
 		frappe.throw(_("Selected amount exceeds the unallocated bank transaction amount."))
 
-	for row in normalised_vouchers:
-		assert_voucher_access(row["payment_doctype"], row["payment_name"])
-
-	updated_transaction = reconcile_vouchers(transaction.name, json.dumps(normalised_vouchers))
+	reconciliation_vouchers = _prepare_reconciliation_vouchers(
+		transaction,
+		normalised_vouchers,
+	)
+	updated_transaction = reconcile_vouchers(
+		transaction.name,
+		json.dumps(reconciliation_vouchers),
+	)
 	return {
 		"status": updated_transaction.status,
 		"idempotent": False,

--- a/advanced_bank_reconciliation/api/test_bank_rec.py
+++ b/advanced_bank_reconciliation/api/test_bank_rec.py
@@ -37,6 +37,7 @@ from advanced_bank_reconciliation.advanced_bank_reconciliation.doctype.advance_b
 	TEST_COMPANY_2,
 	TEST_CUSTOMER,
 	create_test_bank_transaction,
+	create_test_purchase_invoice,
 	create_test_sales_invoice,
 	ensure_bank_account_for_company,
 	setup_abr_test_data,
@@ -250,6 +251,23 @@ class TestBankRecPhaseTwoAPI(FrappeTestCase):
 		)
 		return bank_transaction, sales_invoice
 
+	def _candidate_payload(self, bank_transaction, document_types, voucher_name):
+		result = get_match_candidates(
+			bank_transaction.name,
+			document_types=document_types,
+			from_date=add_days(nowdate(), -1),
+			to_date=add_days(nowdate(), 1),
+		)
+		candidate = next(
+			row for row in result["candidates"] if row["voucher_name"] == voucher_name
+		)
+		return {
+			"voucher_type": candidate["voucher_type"],
+			"source_type": candidate["source_type"],
+			"voucher_name": candidate["voucher_name"],
+			"amount": abs(flt(candidate["amount"])),
+		}
+
 	def test_match_candidates_return_unpaid_sales_invoice(self):
 		bank_transaction, sales_invoice = self._sales_invoice_match_fixture()
 
@@ -271,27 +289,121 @@ class TestBankRecPhaseTwoAPI(FrappeTestCase):
 		self.assertIn(row["confidence"], {"high", "medium", "low"})
 		self.assertIn("Amount", row["reasons"])
 
-	def test_submit_match_reconciles_sales_invoice(self):
+	def test_submit_match_creates_payment_entry_for_unpaid_sales_invoice(self):
 		bank_transaction, sales_invoice = self._sales_invoice_match_fixture(amount=90)
+		voucher = self._candidate_payload(
+			bank_transaction,
+			["unpaid_sales_invoice"],
+			sales_invoice.name,
+		)
+
+		result = submit_match(bank_transaction.name, [voucher])
+
+		self.assertEqual(result["status"], "Reconciled")
+		bank_transaction.reload()
+		sales_invoice.reload()
+		self.assertEqual(bank_transaction.status, "Reconciled")
+		self.assertAlmostEqual(flt(bank_transaction.unallocated_amount), 0.0, places=2)
+		self.assertEqual(len(bank_transaction.payment_entries), 1)
+		linked_payment = bank_transaction.payment_entries[0]
+		self.assertEqual(linked_payment.payment_document, "Payment Entry")
+		payment_entry = frappe.get_doc("Payment Entry", linked_payment.payment_entry)
+		self.assertEqual(payment_entry.docstatus, 1)
+		self.assertEqual(payment_entry.payment_type, "Receive")
+		self.assertTrue(
+			any(
+				row.reference_doctype == "Sales Invoice"
+				and row.reference_name == sales_invoice.name
+				and flt(row.allocated_amount) == 90
+				for row in payment_entry.references
+			)
+		)
+		self.assertAlmostEqual(flt(sales_invoice.outstanding_amount), 0.0, places=2)
+		self.assertEqual(sales_invoice.status, "Paid")
+
+	def test_submit_match_creates_payment_entry_for_unpaid_purchase_invoice(self):
+		purchase_invoice = create_test_purchase_invoice(outstanding=110)
+		bank_transaction = create_test_bank_transaction(
+			self.bank_account_a,
+			withdrawal=110,
+			reference_number="_ABR-PHASE2-PI-MATCH",
+		)
+		voucher = self._candidate_payload(
+			bank_transaction,
+			["unpaid_purchase_invoice"],
+			purchase_invoice.name,
+		)
+
+		result = submit_match(bank_transaction.name, [voucher])
+
+		self.assertEqual(result["status"], "Reconciled")
+		bank_transaction.reload()
+		purchase_invoice.reload()
+		self.assertEqual(len(bank_transaction.payment_entries), 1)
+		linked_payment = bank_transaction.payment_entries[0]
+		self.assertEqual(linked_payment.payment_document, "Payment Entry")
+		payment_entry = frappe.get_doc("Payment Entry", linked_payment.payment_entry)
+		self.assertEqual(payment_entry.docstatus, 1)
+		self.assertEqual(payment_entry.payment_type, "Pay")
+		self.assertTrue(
+			any(
+				row.reference_doctype == "Purchase Invoice"
+				and row.reference_name == purchase_invoice.name
+				and flt(row.allocated_amount) == 110
+				for row in payment_entry.references
+			)
+		)
+		self.assertAlmostEqual(flt(purchase_invoice.outstanding_amount), 0.0, places=2)
+		self.assertEqual(purchase_invoice.status, "Paid")
+
+	def test_submit_match_preserves_explicit_regular_sales_invoice_match(self):
+		bank_transaction, sales_invoice = self._sales_invoice_match_fixture(amount=65)
 
 		result = submit_match(
 			bank_transaction.name,
 			[
 				{
 					"voucher_type": "Sales Invoice",
+					"source_type": "Sales Invoice",
 					"voucher_name": sales_invoice.name,
-					"amount": 90,
+					"amount": 65,
 				}
 			],
 		)
 
 		self.assertEqual(result["status"], "Reconciled")
 		bank_transaction.reload()
-		self.assertEqual(bank_transaction.status, "Reconciled")
-		self.assertAlmostEqual(flt(bank_transaction.unallocated_amount), 0.0, places=2)
-		self.assertTrue(
-			any(row.payment_entry == sales_invoice.name for row in bank_transaction.payment_entries)
+		self.assertEqual(len(bank_transaction.payment_entries), 1)
+		linked_payment = bank_transaction.payment_entries[0]
+		self.assertEqual(linked_payment.payment_document, "Sales Invoice")
+		self.assertEqual(linked_payment.payment_entry, sales_invoice.name)
+
+	def test_submit_match_preserves_explicit_regular_purchase_invoice_match(self):
+		purchase_invoice = create_test_purchase_invoice(outstanding=70)
+		bank_transaction = create_test_bank_transaction(
+			self.bank_account_a,
+			withdrawal=70,
+			reference_number="_ABR-PHASE2-REGULAR-PI-MATCH",
 		)
+
+		result = submit_match(
+			bank_transaction.name,
+			[
+				{
+					"voucher_type": "Purchase Invoice",
+					"source_type": "Purchase Invoice",
+					"voucher_name": purchase_invoice.name,
+					"amount": 70,
+				}
+			],
+		)
+
+		self.assertEqual(result["status"], "Reconciled")
+		bank_transaction.reload()
+		self.assertEqual(len(bank_transaction.payment_entries), 1)
+		linked_payment = bank_transaction.payment_entries[0]
+		self.assertEqual(linked_payment.payment_document, "Purchase Invoice")
+		self.assertEqual(linked_payment.payment_entry, purchase_invoice.name)
 
 	def test_submit_match_rejects_negative_allocation_amount(self):
 		bank_transaction, sales_invoice = self._sales_invoice_match_fixture(amount=45)
@@ -397,11 +509,11 @@ class TestBankRecPhaseTwoAPI(FrappeTestCase):
 	def test_duplicate_submit_returns_idempotent_response_for_same_voucher(self):
 		bank_transaction, sales_invoice = self._sales_invoice_match_fixture(amount=75)
 		vouchers = [
-			{
-				"voucher_type": "Sales Invoice",
-				"voucher_name": sales_invoice.name,
-				"amount": 75,
-			}
+			self._candidate_payload(
+				bank_transaction,
+				["unpaid_sales_invoice"],
+				sales_invoice.name,
+			)
 		]
 
 		submit_match(bank_transaction.name, vouchers)
@@ -1211,11 +1323,13 @@ class TestBankRecPhaseFiveAPI(FrappeTestCase):
 			[
 				{
 					"voucher_type": "Sales Invoice",
+					"source_type": "Unpaid Sales Invoice",
 					"voucher_name": first_invoice.name,
 					"amount": 2000,
 				},
 				{
 					"voucher_type": "Sales Invoice",
+					"source_type": "Unpaid Sales Invoice",
 					"voucher_name": second_invoice.name,
 					"amount": 2950,
 				},
@@ -1230,8 +1344,22 @@ class TestBankRecPhaseFiveAPI(FrappeTestCase):
 		row = next(row for row in result["rows"] if row["name"] == bank_transaction.name)
 
 		self.assertEqual(len(row["linked_payments"]), 2)
+		self.assertTrue(
+			all(
+				payment["payment_document"] == "Payment Entry"
+				for payment in row["linked_payments"]
+			)
+		)
+		payment_entries = [
+			frappe.get_doc("Payment Entry", payment["payment_entry"])
+			for payment in row["linked_payments"]
+		]
 		self.assertEqual(
-			{payment["payment_entry"] for payment in row["linked_payments"]},
+			{
+				reference.reference_name
+				for payment_entry in payment_entries
+				for reference in payment_entry.references
+			},
 			{first_invoice.name, second_invoice.name},
 		)
 		self.assertAlmostEqual(

--- a/bank_rec/src/components/MatchPanel.vue
+++ b/bank_rec/src/components/MatchPanel.vue
@@ -150,6 +150,7 @@ function submit() {
 
   const vouchers = selectedCandidates.value.map((candidate) => ({
     voucher_type: candidate.voucher_type,
+    source_type: candidate.source_type,
     voucher_name: candidate.voucher_name,
     amount: allocationAmount(candidate),
   }));

--- a/bank_rec/src/types/bankRec.ts
+++ b/bank_rec/src/types/bankRec.ts
@@ -114,7 +114,7 @@ export type MatchConfidence = "high" | "medium" | "low";
 export interface MatchCandidate {
   rank: number;
   voucher_type: string;
-  source_type?: string;
+  source_type: string;
   voucher_name: string;
   amount: number;
   reference_number?: string;
@@ -141,6 +141,7 @@ export interface MatchCandidatesResponse {
 
 export interface MatchVoucherSelection {
   voucher_type: string;
+  source_type: string;
   voucher_name: string;
   amount: number;
 }


### PR DESCRIPTION
## Summary

- preserve the candidate source type when the new reconciliation UI submits a match
- create and submit Payment Entries for unpaid sales and purchase invoice candidates before bank reconciliation
- keep regular invoice and voucher matches on the direct reconciliation path
- preserve idempotent retries by resolving invoice references through linked Payment Entries

## Validation

- focused bank reconciliation API suite: 47 tests passed
- full app suite: 262 tests passed
- production Vue build: passed
- visual local demo test: unpaid sales invoice match created a linked receive Payment Entry and paid the invoice
- visual local demo test: unpaid purchase invoice match created a linked pay Payment Entry and paid the invoice
- matched UI showed Payment Entry links for both flows
- independent final code review: no findings

## Release

Patch release via the semantic `fix:` commit type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bank reconciliation now supports matching unpaid sales and purchase invoices.
  * Matching an unpaid invoice can automatically create and reconcile a submitted payment entry.
  * Payment entry links and referenced invoices are shown for split-payment matches.
* **Bug Fixes**
  * Improved duplicate-match detection, including previously linked payment entries.
  * Preserved invoice source information during matching for more reliable reconciliation.
  * Regular invoice matches continue to be handled explicitly and consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->